### PR TITLE
Add Vec::from_array_unchecked

### DIFF
--- a/src/vec.rs
+++ b/src/vec.rs
@@ -92,6 +92,16 @@ impl<T, const N: usize> Vec<T, N> {
         Ok(v)
     }
 
+    /// Constructs a new vector with a fixed capacity of `N` from it's raw parts
+    #[inline]
+    pub unsafe fn from_array_unchecked(buffer: [MaybeUninit<T>; N], len: usize) -> Self
+    {
+        Vec {
+            buffer,
+            len
+        }
+    }
+
     /// Clones a vec into a new vec
     pub(crate) fn clone(&self) -> Self
     where


### PR DESCRIPTION
I'm working on a new version of [swap_queue](https://crates.io/crates/swap-queue) that integrates with `heapless::Vec`, but for my use case I want to be able to construct this by passing ownership of a buffer  `[MaybeUninit<T>; M]` so that there's no cloning. Please add this behavior and feel free to make any changes per your discretion