### PR TITLE
Use `portable-atomic` instead of `atomic-polyfill`.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
           - nightly
         features:
           - ""
-          - "cas"
+          - "cas,portable-atomic/critical-section"
           - "serde"
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [breaking-change] export `IndexMapKeys`, `IndexMapValues` and
   `IndexMapValuesMut` iterator types.
 
-- [breaking-change] this crate now depends on `atomic-polyfill` v1.0.1, meaning that targets that
-  require a polyfill need a `critical-section` **v1.x.x** implementation.
+- [breaking-change] this crate now uses `portable-atomic` v1.0 instead of `atomic-polyfill` for emulating
+  CAS instructions on targets where they're not natively available.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ version = "0.8.0"
 
 [features]
 default = ["cas"]
-cas = ["atomic-polyfill"]
+cas = ["portable-atomic"]
 ufmt-impl = ["ufmt-write"]
 # only for tests
 __trybuild = []
@@ -26,19 +26,22 @@ mpmc_large = []
 defmt-impl = ["defmt"]
 
 [target.thumbv6m-none-eabi.dependencies]
-atomic-polyfill = { version = "1.0.1", optional = true }
+portable-atomic = { version = "1.0", optional = true }
 
 [target.riscv32i-unknown-none-elf.dependencies]
-atomic-polyfill = { version = "1.0.1" }
+portable-atomic = { version = "1.0" }
 
 [target.riscv32imc-unknown-none-elf.dependencies]
-atomic-polyfill = { version = "1.0.1" }
+portable-atomic = { version = "1.0" }
+
+[target.msp430-none-elf.dependencies]
+portable-atomic = { version = "1.0" }
 
 [target.xtensa-esp32s2-none-elf.dependencies]
-atomic-polyfill = { version = "1.0.1" }
+portable-atomic = { version = "1.0", optional = true }
 
 [target.'cfg(target_arch = "avr")'.dependencies]
-atomic-polyfill = { version = "1.0.1", optional = true }
+portable-atomic = { version = "1.0", optional = true }
 
 [dependencies]
 hash32 = "0.3.0"

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -1,8 +1,7 @@
 //! A fixed capacity Multiple-Producer Multiple-Consumer (MPMC) lock-free queue
 //!
-//! NOTE: This module is not available on targets that do *not* support CAS operations and are not
-//! emulated by the [`atomic_polyfill`](https://crates.io/crates/atomic-polyfill) crate (e.g.,
-//! MSP430).
+//! NOTE: This module requires atomic CAS operations. On targets where they're not natively available,
+//! they are emulated by the [`portable-atomic`](https://crates.io/crates/portable-atomic) crate.
 //!
 //! # Example
 //!
@@ -77,10 +76,9 @@
 //!
 //! This module requires CAS atomic instructions which are not available on all architectures
 //! (e.g.  ARMv6-M (`thumbv6m-none-eabi`) and MSP430 (`msp430-none-elf`)). These atomics can be
-//! emulated however with [`atomic_polyfill`](https://crates.io/crates/atomic-polyfill), which is
+//! emulated however with [`portable-atomic`](https://crates.io/crates/portable-atomic), which is
 //! enabled with the `cas` feature and is enabled by default for `thumbv6m-none-eabi` and `riscv32`
-//! targets. MSP430 is currently not supported by
-//! [`atomic_polyfill`](https://crates.io/crates/atomic-polyfill).
+//! targets.
 //!
 //! # References
 //!
@@ -90,19 +88,17 @@
 
 use core::{cell::UnsafeCell, mem::MaybeUninit};
 
-#[cfg(all(feature = "mpmc_large", not(cas_atomic_polyfill)))]
-type AtomicTargetSize = core::sync::atomic::AtomicUsize;
-#[cfg(all(feature = "mpmc_large", cas_atomic_polyfill))]
-type AtomicTargetSize = atomic_polyfill::AtomicUsize;
-#[cfg(all(not(feature = "mpmc_large"), not(cas_atomic_polyfill)))]
-type AtomicTargetSize = core::sync::atomic::AtomicU8;
-#[cfg(all(not(feature = "mpmc_large"), cas_atomic_polyfill))]
-type AtomicTargetSize = atomic_polyfill::AtomicU8;
+#[cfg(not(use_portable_atomic_cas))]
+use core::sync::atomic;
+#[cfg(use_portable_atomic_cas)]
+use portable_atomic as atomic;
 
-#[cfg(not(cas_atomic_polyfill))]
-type Ordering = core::sync::atomic::Ordering;
-#[cfg(cas_atomic_polyfill)]
-type Ordering = atomic_polyfill::Ordering;
+use atomic::Ordering;
+
+#[cfg(feature = "mpmc_large")]
+type AtomicTargetSize = atomic::AtomicUsize;
+#[cfg(not(feature = "mpmc_large"))]
+type AtomicTargetSize = atomic::AtomicU8;
 
 #[cfg(feature = "mpmc_large")]
 type IntSize = usize;

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -2,8 +2,13 @@
 //!
 //! Implementation based on <https://www.codeproject.com/Articles/43510/Lock-Free-Single-Producer-Single-Consumer-Circular>
 //!
-//! NOTE: This module is not available on targets that do *not* support atomic loads and are not
-//! supported by [`atomic_polyfill`](https://crates.io/crates/atomic-polyfill). (e.g., MSP430).
+//! # Portability
+//!
+//! This module requires CAS atomic instructions which are not available on all architectures
+//! (e.g.  ARMv6-M (`thumbv6m-none-eabi`) and MSP430 (`msp430-none-elf`)). These atomics can be
+//! emulated however with [`portable-atomic`](https://crates.io/crates/portable-atomic), which is
+//! enabled with the `cas` feature and is enabled by default for `thumbv6m-none-eabi` and `riscv32`
+//! targets.
 //!
 //! # Examples
 //!
@@ -91,10 +96,12 @@
 
 use core::{cell::UnsafeCell, fmt, hash, mem::MaybeUninit, ptr};
 
-#[cfg(full_atomic_polyfill)]
-use atomic_polyfill::{AtomicUsize, Ordering};
-#[cfg(not(full_atomic_polyfill))]
-use core::sync::atomic::{AtomicUsize, Ordering};
+#[cfg(not(use_portable_atomic))]
+use core::sync::atomic;
+#[cfg(use_portable_atomic)]
+use portable_atomic as atomic;
+
+use atomic::{AtomicUsize, Ordering};
 
 /// A statically allocated single producer single consumer queue with a capacity of `N - 1` elements
 ///


### PR DESCRIPTION
I intend to deprecate `atomic-polyfill` soon, in favor of `portable-atomic`. It supports more archs and is more actively maintained. ~The only thing it can't do yet is use `critical-section`, but it should soon~ it already can: https://github.com/taiki-e/portable-atomic/pull/51