### PR TITLE
Make Vec::as_mut_slice public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - `defmt-impl` is now `defmt-03`
   - `ufmt-impl` is now `ufmt`
   - `cas` is removed, atomic polyfilling is now opt-in via the `portable-atomic` feature.
+- `Vec::as_mut_slice` is now a public method.
 
 ### Fixed
 

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -158,7 +158,7 @@ impl<T, const N: usize> Vec<T, N> {
 
     /// Extracts a mutable slice containing the entire vector.
     ///
-    /// Equivalent to `&s[..]`.
+    /// Equivalent to `&mut s[..]`.
     ///
     /// # Examples
     ///
@@ -168,7 +168,7 @@ impl<T, const N: usize> Vec<T, N> {
     /// buffer[0] = 9;
     /// assert_eq!(buffer.as_slice(), &[9, 2, 3, 5, 8]);
     /// ```
-    pub(crate) fn as_mut_slice(&mut self) -> &mut [T] {
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
         // NOTE(unsafe) avoid bound checks in the slicing operation
         // &mut buffer[..self.len]
         unsafe { slice::from_raw_parts_mut(self.buffer.as_mut_ptr() as *mut T, self.len) }


### PR DESCRIPTION
It is already available through `DerefMut` so making it public doesn't do any harm and makes using slice mut methods a little bit clearer. For example:

`(&mut s[..]).get_mut(i)` vs `s.as_mut_slice().get_mut(i)`
