### PR TITLE
Fix pool (mis)compile on AArch64

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -88,9 +88,13 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
     }
 
-    match compile_probe(ARM_LLSC_PROBE) {
-        Some(status) if status.success() => println!("cargo:rustc-cfg=arm_llsc"),
-        _ => {}
+    // AArch64 instruction set contains `clrex` but not `ldrex` or `strex`; the
+    // probe will succeed when we already know to deny this target from LLSC.
+    if !target.starts_with("aarch64") {
+        match compile_probe(ARM_LLSC_PROBE) {
+            Some(status) if status.success() => println!("cargo:rustc-cfg=arm_llsc"),
+            _ => {}
+        }
     }
 
     Ok(())


### PR DESCRIPTION
Fixes #349

Alternatively we could change the probe to something like:

```rust
#[no_mangle]
pub unsafe fn probe(x: &usize, y: usize) -> usize {
    let mut ret;
    asm!(
        "       clrex",
        "2:",
        "       ldrex {2}, [{0}]",
        "       strex {tmp}, {1}, [{0}]",
        "       cmp {tmp}, #0",
        "       bne 2b",
        in(reg) x,
        in(reg) y,
        out(reg) ret,
        tmp = out(reg) _,
    );
    ret
}
```

Without explicitly denying any `aarch64*` target.