### PR TITLE
Impl conversion from array to Vec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `format` macro.
 - Added `String::from_utf16`.
 - Added `is_full`, `recent_index`, `oldest`, and `oldest_index` to `HistoryBuffer`
+- Added infallible conversions from arrays to `Vec`.
 
 ### Changed
 

--- a/src/sealed.rs
+++ b/src/sealed.rs
@@ -4,6 +4,11 @@ pub(crate) const fn smaller_than<const N: usize, const MAX: usize>() {
 }
 
 #[allow(dead_code, path_statements, clippy::no_effect)]
+pub(crate) const fn greater_than_eq<const N: usize, const MIN: usize>() {
+    Assert::<N, MIN>::GREATER_EQ;
+}
+
+#[allow(dead_code, path_statements, clippy::no_effect)]
 pub(crate) const fn greater_than_eq_0<const N: usize>() {
     Assert::<N, 0>::GREATER_EQ;
 }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1601,6 +1601,23 @@ mod tests {
     }
 
     #[test]
+    fn from_array_no_drop() {
+        struct Drops(Option<u8>);
+
+        impl Drop for Drops {
+            fn drop(&mut self) {
+                self.0 = None;
+            }
+        }
+
+        let v: Vec<Drops, 3> = Vec::from([Drops(Some(1)), Drops(Some(2)), Drops(Some(3))]);
+
+        assert_eq!(v[0].0, Some(1));
+        assert_eq!(v[1].0, Some(2));
+        assert_eq!(v[2].0, Some(3));
+    }
+
+    #[test]
     fn starts_with() {
         let v: Vec<_, 8> = Vec::from_slice(b"ab").unwrap();
         assert!(v.starts_with(&[]));


### PR DESCRIPTION
This PR implements conversion from arrays to vec. The array does not have to be the same length as the capacity of the vec. Const generics are asserted at compile time. Unfortunately the method currently requires a copy of the source array.

Partially addresses requests in #341 and #344.

Also I'm not totally happy about the const assertions given #351. I've not added any tests in the `cfail` suite as I don't think we can practically check this with `trybuild` at the moment. There is a bit of a work-around you can do but it's not pretty.

## Questions

1. Would we prefer to just implement `From<[T; N]> for Vec<T, N>`? One of the issues with this impl is that users will need to be explicit about vec capacity. Because lengths `N` and `M` can be different, you can't write:

   ```rust
   let v = Vec::from([1, 2, 3]);
   ```

   It needs to be:

   ```rust
   let v = Vec::<_, 3>::from([1, 2, 3]);
   ```

2. Should `from_array` be internal, and the API exposed by the crate simply be the `From` trait?