### PR TITLE
indexmap: use correct index when inserting through entry api

### DIFF
--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -209,12 +209,9 @@ where
                     // robin hood: steal the spot if it's better for us
                     let index = self.entries.len();
                     unsafe { self.entries.push_unchecked(Bucket { hash, key, value }) };
+                    Self::insert_phase_2(&mut self.indices, probe, Pos::new(index, hash));
                     return Insert::Success(Inserted {
-                        index: Self::insert_phase_2(
-                            &mut self.indices,
-                            probe,
-                            Pos::new(index, hash),
-                        ),
+                        index,
                         old_value: None,
                     });
                 } else if entry_hash == hash && unsafe { self.entries.get_unchecked(i).key == key }
@@ -1372,7 +1369,7 @@ mod tests {
                 panic!("Entry found when empty");
             }
             Entry::Vacant(v) => {
-                v.insert(value).unwrap();
+                assert_eq!(value, *v.insert(value).unwrap());
             }
         };
         assert_eq!(value, *src.get(&key).unwrap())


### PR DESCRIPTION
When inserting using the entry API and the robin-hood case is hit, we currently return using the incorrect index, which in turn returns a reference to the wrong entry in the map, causing undefined behaviour in the API.

Resolves #360 