### PR TITLE
Add ordered_get() to HistoryBuffer

### DIFF
--- a/src/histbuf.rs
+++ b/src/histbuf.rs
@@ -527,16 +527,7 @@ impl<T, S: HistBufStorage<T> + ?Sized> HistoryBufferInner<T, S> {
     /// assert_eq!(buffer.ordered_get(6), None);
     /// ```
     pub fn ordered_get(&self, idx: usize) -> Option<&T> {
-        if self.len() <= idx {
-            None
-        } else {
-            let (front, back) = self.as_slices();
-            if idx < front.len() {
-                Some(&front[idx])
-            } else {
-                Some(&back[idx - front.len()])
-            }
-        }
+        self.oldest_ordered().nth(idx)
     }
 
     /// Returns double ended iterator for iterating over the buffer from

--- a/src/histbuf.rs
+++ b/src/histbuf.rs
@@ -504,14 +504,14 @@ impl<T, S: HistBufStorage<T> + ?Sized> HistoryBufferInner<T, S> {
         }
     }
 
-    /// Returns a reference to the element in the order from oldest to newest
+    /// Returns a reference to the element in the order from oldest to newest.
     ///
-    /// `buf.ordered_get(0)` will always return the oldest element in the buffer
+    /// `buf.ordered_get(0)` will always return the oldest element in the buffer.
     ///
     /// `buf.ordered_get(buf.len() - 1)` will always return the newest element
-    /// in the buffer
+    /// in the buffer.
     ///
-    /// Returns None if `index >= self.len()`
+    /// Returns None if `index >= self.len()`.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
This allows users to get access to the elements of the history buffer in historical order.