### PR TITLE
Update spin 0.9.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ atomic-polyfill = { version = "1.0.1", optional = true }
 hash32 = "0.3.0"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
-spin = "0.9.4"
+spin = "0.9.8"
 
 [dependencies.serde]
 version = "1"


### PR DESCRIPTION
Update spin to 0.9.8.  Although not directly exploitable this will help with dependent libraries which are flagging this security issue: https://github.com/advisories/GHSA-2qv5-7mw5-j3cg