### PR TITLE
add format macro implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Added `format` macro.
+
 ### Changed
 
 - Changed `stable_deref_trait` to a platform-dependent dependency.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ mod histbuf;
 mod indexmap;
 mod indexset;
 mod linear_map;
-pub mod string;
+mod string;
 mod vec;
 
 #[cfg(feature = "serde")]
@@ -134,3 +134,10 @@ pub mod spsc;
 mod ufmt;
 
 mod sealed;
+
+/// Implementation details for macros.
+/// Do not use. Used for macros only. Not covered by semver guarantees.
+#[doc(hidden)]
+pub mod _export {
+    pub use crate::string::format;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ mod histbuf;
 mod indexmap;
 mod indexset;
 mod linear_map;
-mod string;
+pub mod string;
 mod vec;
 
 #[cfg(feature = "serde")]

--- a/src/string.rs
+++ b/src/string.rs
@@ -637,11 +637,11 @@ macro_rules! format {
     // Without semicolon as separator to disambiguate between arms, Rust just
     // chooses the first so that the format string would land in $max.
     ($max:expr; $($arg:tt)*) => {{
-        let res = $crate::string::format::<$max>(core::format_args!($($arg)*));
+        let res = $crate::_export::format::<$max>(core::format_args!($($arg)*));
         res
     }};
     ($($arg:tt)*) => {{
-        let res = $crate::string::format(core::format_args!($($arg)*));
+        let res = $crate::_export::format(core::format_args!($($arg)*));
         res
     }};
 }


### PR DESCRIPTION
Motivation:
If you want to create a formatted `heapless::String` at the moment, it is necessary to create a mutable string and modify it:

```rust
let mut string = heapless::String::<10>::new();
write!(&mut string, "{:>3}cm", height).unwrap();
```

It's a bit nicer to have a `format!` macro that constructs the `String` in-place without requiring an intermediate step, just as Rust's standard library offers.

```rust
let string = format!(10, "{:>3}cm", height);
```
