### PR TITLE
Fix Linear Map for Cargo 1.71

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,65 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'heapless'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=heapless"
+                ],
+                "filter": {
+                    "name": "heapless",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'tsan'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=tsan",
+                    "--package=heapless"
+                ],
+                "filter": {
+                    "name": "tsan",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'cpass'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=cpass",
+                    "--package=heapless"
+                ],
+                "filter": {
+                    "name": "cpass",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   require a polyfill need a `critical-section` **v1.x.x** implementation.
 
 ### Fixed
+- Linear Map `Drop` impl
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Implemented `retain` for `IndexMap` and `IndexSet`.
 - Recover `StableDeref` trait for `pool::object::Object` and `pool::boxed::Box`.
 - Add polyfills for ESP32S2
+- `HistoryBuffer.pop_oldest()`
+- `HistoryBuffer.filled()` getter to replace filled member variable
+- `HistoryBuffer` unit tests for `HistoryBuffer.pop_oldest`.
 
 ### Changed
 
@@ -33,6 +36,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - [breaking-change] this crate now depends on `atomic-polyfill` v1.0.1, meaning that targets that
   require a polyfill need a `critical-section` **v1.x.x** implementation.
+
+- `HistoryBuffer.len()` to be a getter rather than computed on call.
+- `HistoryBuffer.write()`
+- `HistoryBuffer.recent()`
+- `HistoryBuffer.oldest_ordered()`
+- `OldestOrdered.next()`
 
 ### Fixed
 - Linear Map `Drop` impl

--- a/build.rs
+++ b/build.rs
@@ -97,9 +97,13 @@ fn main() -> Result<(), Box<dyn Error>> {
         println!("cargo:rustc-cfg=unstable_channel");
     }
 
-    match compile_probe(ARM_LLSC_PROBE) {
-        Some(status) if status.success() => println!("cargo:rustc-cfg=arm_llsc"),
-        _ => {}
+    // AArch64 instruction set contains `clrex` but not `ldrex` or `strex`; the
+    // probe will succeed when we already know to deny this target from LLSC.
+    if !target.starts_with("aarch64") {
+        match compile_probe(ARM_LLSC_PROBE) {
+            Some(status) if status.success() => println!("cargo:rustc-cfg=arm_llsc"),
+            _ => {}
+        }
     }
 
     Ok(())

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -461,12 +461,6 @@ impl<'a, K, V> Clone for Iter<'a, K, V> {
     }
 }
 
-impl<K, V, const N: usize> Drop for LinearMap<K, V, N> {
-    fn drop(&mut self) {
-        unsafe { ptr::drop_in_place(self.buffer.as_mut_slice()) }
-    }
-}
-
 pub struct IterMut<'a, K, V> {
     iter: slice::IterMut<'a, (K, V)>,
 }

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -1,5 +1,5 @@
 use crate::Vec;
-use core::{borrow::Borrow, fmt, iter::FromIterator, mem, ops, slice};
+use core::{borrow::Borrow, fmt, iter::FromIterator, mem, ops, slice, ptr};
 
 /// A fixed capacity map / dictionary that performs lookups via linear search
 ///
@@ -463,10 +463,7 @@ impl<'a, K, V> Clone for Iter<'a, K, V> {
 
 impl<K, V, const N: usize> Drop for LinearMap<K, V, N> {
     fn drop(&mut self) {
-        // heapless::Vec implements drop right?
-        drop(&self.buffer);
-        // original code below
-        // unsafe { ptr::drop_in_place(self.buffer.as_mut_slice()) }
+        unsafe { ptr::drop_in_place(self.buffer.as_mut_slice()) }
     }
 }
 


### PR DESCRIPTION
## Motivation

In the latest version of Cargo the implementation of `Drop` for linear map does not compile.

## Changes

Revert `Drop` impl to previous implementation.