### PR TITLE
HistoryBuffer Add pop_oldest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Implemented `retain` for `IndexMap` and `IndexSet`.
 - Recover `StableDeref` trait for `pool::object::Object` and `pool::boxed::Box`.
 - Add polyfills for ESP32S2
-- - `HistoryBuffer.pop_oldest()`
+- `HistoryBuffer.pop_oldest()`
 - `HistoryBuffer.filled()` getter to replace filled member variable
 - `HistoryBuffer` unit tests for `HistoryBuffer.pop_oldest`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Implemented `retain` for `IndexMap` and `IndexSet`.
 - Recover `StableDeref` trait for `pool::object::Object` and `pool::boxed::Box`.
 - Add polyfills for ESP32S2
+- - `HistoryBuffer.pop_oldest()`
+- `HistoryBuffer.filled()` getter to replace filled member variable
+- `HistoryBuffer` unit tests for `HistoryBuffer.pop_oldest`.
 
 ### Changed
 
@@ -33,6 +36,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - [breaking-change] this crate now depends on `atomic-polyfill` v1.0.1, meaning that targets that
   require a polyfill need a `critical-section` **v1.x.x** implementation.
+
+- `HistoryBuffer.len()` to be a getter rather than computed on call.
+- `HistoryBuffer.write()`
+- `HistoryBuffer.recent()`
+- `HistoryBuffer.oldest_ordered()`
+- `OldestOrdered.next()`
 
 ### Fixed
 

--- a/build.rs
+++ b/build.rs
@@ -97,13 +97,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         println!("cargo:rustc-cfg=unstable_channel");
     }
 
-    // AArch64 instruction set contains `clrex` but not `ldrex` or `strex`; the
-    // probe will succeed when we already know to deny this target from LLSC.
-    if !target.starts_with("aarch64") {
-        match compile_probe(ARM_LLSC_PROBE) {
-            Some(status) if status.success() => println!("cargo:rustc-cfg=arm_llsc"),
-            _ => {}
-        }
+    match compile_probe(ARM_LLSC_PROBE) {
+        Some(status) if status.success() => println!("cargo:rustc-cfg=arm_llsc"),
+        _ => {}
     }
 
     Ok(())

--- a/src/histbuf.rs
+++ b/src/histbuf.rs
@@ -629,7 +629,7 @@ mod tests {
         assert_eq_iter(x.oldest_ordered(), &[3, 4, 5, 6]);
 
         // clear via pop
-        for i in 3..6 {
+        for i in 3..=6 {
             assert_eq!(x.pop_oldest(), Some(i));
         }
 
@@ -638,7 +638,7 @@ mod tests {
         // clear again from empty
         x.extend(&[1, 2, 3, 4, 5, 6, 7, 8]);
 
-        for i in 4..8 {
+        for i in 4..=8 {
             assert_eq!(x.pop_oldest(), Some(i));
         }
 

--- a/src/histbuf.rs
+++ b/src/histbuf.rs
@@ -202,11 +202,7 @@ impl<T, const N: usize> HistoryBuffer<T, N> {
     pub fn as_slice(&self) -> &[T] {
         unsafe {
             slice::from_raw_parts(
-                self.data
-                    .as_ptr()
-                    .add((self.write_at + self.capacity() - self.len()) % self.capacity())
-                    as *const _,
-                self.len(),
+                self.data.as_ptr() as *const _, self.len(),
             )
         }
     }
@@ -383,7 +379,7 @@ impl<'a, T, const N: usize> Iterator for OldestOrdered<'a, T, N> {
             return None;
         }
 
-        let item = &self.buf[self.cur];
+        let item = unsafe { self.buf.data[self.cur].assume_init_ref() };
         self.cur += 1;
         Some(item)
     }


### PR DESCRIPTION
## Motivation
There currently is no interface for removing elements from the HistoryBuffer.

## Added
- `HistoryBuffer.pop_oldest()`
- `HistoryBuffer.filled()` getter to replace `filled` member variable
- Unit test for `HistoryBuffer.pop_oldest()`

## Changed
- `HistoryBuffer.len()` to be a getter rather than computed on call.
- `HistoryBuffer.write()`
- `HistoryBuffer.recent()`
- `HistoryBuffer.oldest_ordered()`
- `OldestOrdered.next()`

## Warning
`HistoryBuffer.as_slice()` no longer has the same meaning. The slice returned may contain unused values.