### PR TITLE
Fix dropping_references warning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
     branches: [main]
   push:
     branches: [staging, trying]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -337,8 +338,6 @@ jobs:
 
       - name: Run cargo
         run: cargo run
-
-
 
   # Refs: https://github.com/rust-lang/crater/blob/9ab6f9697c901c4a44025cf0a39b73ad5b37d198/.github/workflows/bors.yml#L125-L149
   #

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -283,6 +283,7 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
           target: ${{ matrix.target }}
+          components: rust-src
           override: true
 
       - name: Export variables
@@ -295,7 +296,7 @@ jobs:
         with:
           use-cross: false
           command: test
-          args: --test tsan --target=${{ matrix.target }} --features=${{ matrix.features }} ${{ matrix.buildtype }} -- --test-threads=1
+          args: -Zbuild-std --test tsan --target=${{ matrix.target }} --features=${{ matrix.features }} ${{ matrix.buildtype }} -- --test-threads=1
 
   # Run cfail tests on MSRV
   testcfail:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed a `dropping_references` warning in `LinearMap`.
+
 ### Removed
 
 - [breaking-change] this crate no longer has a Minimum Supported Rust Version (MSRV) guarantee and

--- a/cfail/ui/freeze.stderr
+++ b/cfail/ui/freeze.stderr
@@ -2,8 +2,8 @@ error[E0499]: cannot borrow `q` as mutable more than once at a time
  --> $DIR/freeze.rs:7:5
   |
 6 |     let (_p, mut _c) = q.split();
-  |                        --------- first mutable borrow occurs here
+  |                        - first mutable borrow occurs here
 7 |     q.enqueue(0).unwrap();
-  |     ^^^^^^^^^^^^ second mutable borrow occurs here
+  |     ^ second mutable borrow occurs here
 8 |     _c.dequeue();
-  |     ------------ first borrow later used here
+  |     -- first borrow later used here

--- a/cfail/ui/not-send.stderr
+++ b/cfail/ui/not-send.stderr
@@ -1,99 +1,123 @@
 error[E0277]: `*const ()` cannot be sent between threads safely
-  --> $DIR/not-send.rs:19:15
+  --> ui/not-send.rs:19:15
    |
 19 |     is_send::<Consumer<NotSend, 4>>();
    |               ^^^^^^^^^^^^^^^^^^^^ `*const ()` cannot be sent between threads safely
    |
    = help: within `PhantomData<*const ()>`, the trait `Send` is not implemented for `*const ()`
-   = note: required because it appears within the type `PhantomData<*const ()>`
+note: required because it appears within the type `PhantomData<*const ()>`
+  --> $RUST/core/src/marker.rs
    = note: required for `Consumer<'_, PhantomData<*const ()>, 4>` to implement `Send`
 note: required by a bound in `is_send`
-  --> $DIR/not-send.rs:14:8
+  --> ui/not-send.rs:14:8
    |
 12 | fn is_send<T>()
-   |    ------- required by a bound in this
+   |    ------- required by a bound in this function
 13 | where
 14 |     T: Send,
    |        ^^^^ required by this bound in `is_send`
 
 error[E0277]: `*const ()` cannot be sent between threads safely
-  --> $DIR/not-send.rs:20:15
+  --> ui/not-send.rs:20:15
    |
 20 |     is_send::<Producer<NotSend, 4>>();
    |               ^^^^^^^^^^^^^^^^^^^^ `*const ()` cannot be sent between threads safely
    |
    = help: within `PhantomData<*const ()>`, the trait `Send` is not implemented for `*const ()`
-   = note: required because it appears within the type `PhantomData<*const ()>`
+note: required because it appears within the type `PhantomData<*const ()>`
+  --> $RUST/core/src/marker.rs
    = note: required for `Producer<'_, PhantomData<*const ()>, 4>` to implement `Send`
 note: required by a bound in `is_send`
-  --> $DIR/not-send.rs:14:8
+  --> ui/not-send.rs:14:8
    |
 12 | fn is_send<T>()
-   |    ------- required by a bound in this
+   |    ------- required by a bound in this function
 13 | where
 14 |     T: Send,
    |        ^^^^ required by this bound in `is_send`
 
 error[E0277]: `*const ()` cannot be sent between threads safely
-  --> $DIR/not-send.rs:21:15
+  --> ui/not-send.rs:21:15
    |
 21 |     is_send::<Queue<NotSend, 4>>();
    |               ^^^^^^^^^^^^^^^^^ `*const ()` cannot be sent between threads safely
    |
    = help: within `Queue<PhantomData<*const ()>, 4>`, the trait `Send` is not implemented for `*const ()`
-   = note: required because it appears within the type `PhantomData<*const ()>`
-   = note: required because it appears within the type `ManuallyDrop<PhantomData<*const ()>>`
-   = note: required because it appears within the type `MaybeUninit<PhantomData<*const ()>>`
-   = note: required because it appears within the type `UnsafeCell<MaybeUninit<PhantomData<*const ()>>>`
+note: required because it appears within the type `PhantomData<*const ()>`
+  --> $RUST/core/src/marker.rs
+note: required because it appears within the type `ManuallyDrop<PhantomData<*const ()>>`
+  --> $RUST/core/src/mem/manually_drop.rs
+note: required because it appears within the type `MaybeUninit<PhantomData<*const ()>>`
+  --> $RUST/core/src/mem/maybe_uninit.rs
+note: required because it appears within the type `UnsafeCell<MaybeUninit<PhantomData<*const ()>>>`
+  --> $RUST/core/src/cell.rs
    = note: required because it appears within the type `[UnsafeCell<MaybeUninit<PhantomData<*const ()>>>; 4]`
-   = note: required because it appears within the type `Queue<PhantomData<*const ()>, 4>`
+note: required because it appears within the type `Queue<PhantomData<*const ()>, 4>`
+  --> $HEAPLESS/src/spsc.rs
+   |
+   | pub struct Queue<T, const N: usize> {
+   |            ^^^^^
 note: required by a bound in `is_send`
-  --> $DIR/not-send.rs:14:8
+  --> ui/not-send.rs:14:8
    |
 12 | fn is_send<T>()
-   |    ------- required by a bound in this
+   |    ------- required by a bound in this function
 13 | where
 14 |     T: Send,
    |        ^^^^ required by this bound in `is_send`
 
 error[E0277]: `*const ()` cannot be sent between threads safely
-  --> $DIR/not-send.rs:22:15
+  --> ui/not-send.rs:22:15
    |
 22 |     is_send::<Vec<NotSend, 4>>();
    |               ^^^^^^^^^^^^^^^ `*const ()` cannot be sent between threads safely
    |
    = help: within `heapless::Vec<PhantomData<*const ()>, 4>`, the trait `Send` is not implemented for `*const ()`
-   = note: required because it appears within the type `PhantomData<*const ()>`
-   = note: required because it appears within the type `ManuallyDrop<PhantomData<*const ()>>`
-   = note: required because it appears within the type `MaybeUninit<PhantomData<*const ()>>`
+note: required because it appears within the type `PhantomData<*const ()>`
+  --> $RUST/core/src/marker.rs
+note: required because it appears within the type `ManuallyDrop<PhantomData<*const ()>>`
+  --> $RUST/core/src/mem/manually_drop.rs
+note: required because it appears within the type `MaybeUninit<PhantomData<*const ()>>`
+  --> $RUST/core/src/mem/maybe_uninit.rs
    = note: required because it appears within the type `[MaybeUninit<PhantomData<*const ()>>; 4]`
-   = note: required because it appears within the type `heapless::Vec<PhantomData<*const ()>, 4>`
+note: required because it appears within the type `Vec<PhantomData<*const ()>, 4>`
+  --> $HEAPLESS/src/vec.rs
+   |
+   | pub struct Vec<T, const N: usize> {
+   |            ^^^
 note: required by a bound in `is_send`
-  --> $DIR/not-send.rs:14:8
+  --> ui/not-send.rs:14:8
    |
 12 | fn is_send<T>()
-   |    ------- required by a bound in this
+   |    ------- required by a bound in this function
 13 | where
 14 |     T: Send,
    |        ^^^^ required by this bound in `is_send`
 
 error[E0277]: `*const ()` cannot be sent between threads safely
-  --> $DIR/not-send.rs:23:15
+  --> ui/not-send.rs:23:15
    |
 23 |     is_send::<HistoryBuffer<NotSend, 4>>();
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^ `*const ()` cannot be sent between threads safely
    |
    = help: within `HistoryBuffer<PhantomData<*const ()>, 4>`, the trait `Send` is not implemented for `*const ()`
-   = note: required because it appears within the type `PhantomData<*const ()>`
-   = note: required because it appears within the type `ManuallyDrop<PhantomData<*const ()>>`
-   = note: required because it appears within the type `MaybeUninit<PhantomData<*const ()>>`
+note: required because it appears within the type `PhantomData<*const ()>`
+  --> $RUST/core/src/marker.rs
+note: required because it appears within the type `ManuallyDrop<PhantomData<*const ()>>`
+  --> $RUST/core/src/mem/manually_drop.rs
+note: required because it appears within the type `MaybeUninit<PhantomData<*const ()>>`
+  --> $RUST/core/src/mem/maybe_uninit.rs
    = note: required because it appears within the type `[MaybeUninit<PhantomData<*const ()>>; 4]`
-   = note: required because it appears within the type `HistoryBuffer<PhantomData<*const ()>, 4>`
+note: required because it appears within the type `HistoryBuffer<PhantomData<*const ()>, 4>`
+  --> $HEAPLESS/src/histbuf.rs
+   |
+   | pub struct HistoryBuffer<T, const N: usize> {
+   |            ^^^^^^^^^^^^^
 note: required by a bound in `is_send`
-  --> $DIR/not-send.rs:14:8
+  --> ui/not-send.rs:14:8
    |
 12 | fn is_send<T>()
-   |    ------- required by a bound in this
+   |    ------- required by a bound in this function
 13 | where
 14 |     T: Send,
    |        ^^^^ required by this bound in `is_send`

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -461,15 +461,6 @@ impl<'a, K, V> Clone for Iter<'a, K, V> {
     }
 }
 
-impl<K, V, const N: usize> Drop for LinearMap<K, V, N> {
-    fn drop(&mut self) {
-        // heapless::Vec implements drop right?
-        drop(&self.buffer);
-        // original code below
-        // unsafe { ptr::drop_in_place(self.buffer.as_mut_slice()) }
-    }
-}
-
 pub struct IterMut<'a, K, V> {
     iter: slice::IterMut<'a, (K, V)>,
 }
@@ -540,5 +531,25 @@ mod test {
         }
     }
 
-    // TODO: drop test
+    #[test]
+    fn drop() {
+        droppable!();
+
+        {
+            let mut v: LinearMap<i32, Droppable, 2> = LinearMap::new();
+            v.insert(0, Droppable::new()).ok().unwrap();
+            v.insert(1, Droppable::new()).ok().unwrap();
+            v.remove(&1).unwrap();
+        }
+
+        assert_eq!(Droppable::count(), 0);
+
+        {
+            let mut v: LinearMap<i32, Droppable, 2> = LinearMap::new();
+            v.insert(0, Droppable::new()).ok().unwrap();
+            v.insert(1, Droppable::new()).ok().unwrap();
+        }
+
+        assert_eq!(Droppable::count(), 0);
+    }
 }


### PR DESCRIPTION
Please do review this carefully.  I'm not confident this (the fix and the test) is correct.  Note there is `unsafe` in `impl Drop for Vec` which is the backend data structure for `LinearMap`.

A couple CI failures will still occur, see #387.