### PR TITLE
CI: add build.yml to merge group

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 name: Build
 on:
+  merge_group:
   pull_request:
     branches: [main]
   push:


### PR DESCRIPTION
I was wondering why the merge queue was awfully quick.