### PR TITLE
deps: make `stable_deref_trait` an optional dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- configure `stable_deref_trait` as a platform-dependent dependency
+
 ## [v0.8.0] - 2023-11-07
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,12 @@ mpmc_large = []
 portable-atomic = { version = "1.0", optional = true }
 hash32 = "0.3.0"
 serde = { version = "1", optional = true, default-features = false }
-stable_deref_trait = { version = "1", default-features = false }
 ufmt-write = { version = "0.1", optional = true }
 defmt = { version = ">=0.2.0,<0.4", optional = true }
+
+# for the pool module
+[target.'cfg(any(target_arch = "arm", target_arch = "x86"))'.dependencies]
+stable_deref_trait = { version = "1", default-features = false }
 
 [dev-dependencies]
 ufmt = "0.2"


### PR DESCRIPTION
Configures the `stable_deref_trait` to only be included for `arm_llsc` and `target_arch = "x86"` platforms. This is because the dependency is only used for the `pool` module, and the `pool` module is only used on the above platforms.

Reduces the dependency graph for all other platforms.