### PR TITLE
boxed: suppress clippy lint in doctest

### DIFF
--- a/src/pool/boxed.rs
+++ b/src/pool/boxed.rs
@@ -67,6 +67,7 @@
 //! const POOL_CAPACITY: usize = 8;
 //!
 //! let blocks: &'static mut [BoxBlock<u128>] = {
+//!     #[allow(clippy::declare_interior_mutable_const)]
 //!     const BLOCK: BoxBlock<u128> = BoxBlock::new(); // <=
 //!     static mut BLOCKS: [BoxBlock<u128>; POOL_CAPACITY] = [BLOCK; POOL_CAPACITY];
 //!     unsafe { &mut BLOCKS }


### PR DESCRIPTION
Part of #411 