### PR TITLE
Vec: add a "View" that can mutate the vec and erase the const generic.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `Vec::spare_capacity_mut`.
 - Added `Extend` impls for `Deque`.
 - Added `Deque::make_contiguous`.
+- Added `VecView`, the `!Sized` version of `Vec`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `Vec::spare_capacity_mut`.
 - Added `Extend` impls for `Deque`.
 - Added `Deque::make_contiguous`.
-- Added `VecView`, the `!Sized` version of `Vec`
+- Added `VecView`, the `!Sized` version of `Vec`.
 
 ### Changed
 

--- a/cfail/ui/not-send.stderr
+++ b/cfail/ui/not-send.stderr
@@ -72,7 +72,7 @@ error[E0277]: `*const ()` cannot be sent between threads safely
 22 |     is_send::<Vec<NotSend, 4>>();
    |               ^^^^^^^^^^^^^^^ `*const ()` cannot be sent between threads safely
    |
-   = help: within `heapless::Vec<PhantomData<*const ()>, 4>`, the trait `Send` is not implemented for `*const ()`
+   = help: within `heapless::vec::VecInner<[MaybeUninit<PhantomData<*const ()>>; 4]>`, the trait `Send` is not implemented for `*const ()`
 note: required because it appears within the type `PhantomData<*const ()>`
   --> $RUST/core/src/marker.rs
 note: required because it appears within the type `ManuallyDrop<PhantomData<*const ()>>`
@@ -80,11 +80,11 @@ note: required because it appears within the type `ManuallyDrop<PhantomData<*con
 note: required because it appears within the type `MaybeUninit<PhantomData<*const ()>>`
   --> $RUST/core/src/mem/maybe_uninit.rs
    = note: required because it appears within the type `[MaybeUninit<PhantomData<*const ()>>; 4]`
-note: required because it appears within the type `Vec<PhantomData<*const ()>, 4>`
+note: required because it appears within the type `VecInner<[MaybeUninit<PhantomData<*const ()>>; 4]>`
   --> $HEAPLESS/src/vec.rs
    |
-   | pub struct Vec<T, const N: usize> {
-   |            ^^^
+   | pub struct VecInner<B: ?Sized + VecDrop> {
+   |            ^^^^^^^^
 note: required by a bound in `is_send`
   --> ui/not-send.rs:14:8
    |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,9 @@ pub use indexmap::{
 pub use indexset::{FnvIndexSet, IndexSet, Iter as IndexSetIter};
 pub use linear_map::LinearMap;
 pub use string::String;
+#[cfg(doc)]
+#[doc(hidden)]
+pub use vec::VecInner as _;
 pub use vec::{Vec, VecView};
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub use indexmap::{
 pub use indexset::{FnvIndexSet, IndexSet, Iter as IndexSetIter};
 pub use linear_map::LinearMap;
 pub use string::String;
-pub use vec::Vec;
+pub use vec::{Vec, VecView};
 
 #[macro_use]
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,10 @@ pub use indexmap::{
 pub use indexset::{FnvIndexSet, IndexSet, Iter as IndexSetIter};
 pub use linear_map::LinearMap;
 pub use string::String;
+
+// Workaround https://github.com/rust-lang/rust/issues/119015. This is required so that the methods on `VecView` and `Vec` are properly documented.
+// cfg(doc) prevents `VecInner` being part of the public API.
+// doc(hidden) prevents the `pub use vec::VecInner` from being visible in the documentation.
 #[cfg(doc)]
 #[doc(hidden)]
 pub use vec::VecInner as _;

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -64,10 +64,20 @@ pub struct VecInner<B: ?Sized + VecDrop> {
 /// }
 /// assert_eq!(*vec, [7, 1, 2, 3]);
 /// ```
+///
+/// In some cases, the const-generic might be cumbersome. `Vec` can coerce into a [`VecView`][] to remove the need for the const-generic:
+///
+/// ```rust
+/// use heapless::{Vec, VecView};
+///
+/// let vec: Vec<u8, 10> = Vec::from_slice(&[1, 2, 3, 4]).unwrap();
+/// let view: &VecView<_> = &vec;
+/// ```
 pub type Vec<T, const N: usize> = VecInner<[MaybeUninit<T>; N]>;
+
 /// A Vec with dynamic capacity
 ///
-/// [`Vec`]() coerces to `VecView`. `VecView` is !Sized, meaning that it can only ever be used through pointer
+/// [`Vec`]() coerces to `VecView`. `VecView` is `!Sized`, meaning that it can only ever be used through pointer
 ///
 /// Unlike [`Vec`](), `VecView` does not have an `N` const-generic parameter.
 /// This has the ergonomic advantages of making it possible to use functions without needing to know at
@@ -889,11 +899,29 @@ impl<T, const N: usize> Vec<T, N> {
     }
 
     /// Get a reference to the Vec, erasing the `N` const-generic
+    ///
+    /// This can also be used through type coerction, since `Vec<T, N>` implements `Unsize<VecView<T>>`:
+    ///
+    /// ```rust
+    /// use heapless::{Vec, VecView};
+    ///
+    /// let vec: Vec<u8, 10> = Vec::from_slice(&[1, 2, 3, 4]).unwrap();
+    /// let view: &VecView<_> = &vec;
+    /// ```
     pub const fn as_view(&self) -> &VecView<T> {
         self
     }
 
     /// Get a `mut` reference to the Vec, erasing the `N` const-generic
+    ///
+    /// This can also be used through type coerction, since `Vec<T, N>` implements `Unsize<VecView<T>>`:
+    ///
+    /// ```rust
+    /// use heapless::{Vec, VecView};
+    ///
+    /// let mut vec: Vec<u8, 10> = Vec::from_slice(&[1, 2, 3, 4]).unwrap();
+    /// let view: &mut VecView<_> = &mut vec;
+    /// ```
     pub fn as_mut_view(&mut self) -> &mut VecView<T> {
         self
     }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -80,13 +80,13 @@ pub type Vec<T, const N: usize> = VecInner<[MaybeUninit<T>; N]>;
 
 /// A [`Vec`] with dynamic capacity
 ///
-/// [`Vec`] coerces to `VecView`. `VecView` is `!Sized`, meaning that it can only ever be used through pointer
+/// [`Vec`] coerces to `VecView`. `VecView` is `!Sized`, meaning it can only ever be used by reference.
 ///
 /// Unlike [`Vec`], `VecView` does not have an `N` const-generic parameter.
-/// This has the ergonomic advantages of making it possible to use functions without needing to know at
+/// This has the ergonomic advantage of making it possible to use functions without needing to know at
 /// compile-time the size of the buffers used, for example for use in `dyn` traits.
 ///
-/// `VecView<T>` is to `Vec<T, N>` what `[T]` is to `[T; N]`
+/// `VecView<T>` is to `Vec<T, N>` what `[T]` is to `[T; N]`.
 ///
 /// ```rust
 /// use heapless::{Vec, VecView};

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -30,6 +30,7 @@ impl<T, const N: usize> VecDrop for [MaybeUninit<T>; N] {
     }
 }
 
+/// <div class="warn">This is private API and should not be used</div>
 pub struct VecInner<B: ?Sized + VecDrop> {
     len: usize,
     buffer: B,
@@ -866,10 +867,12 @@ impl<T, const N: usize> Vec<T, N> {
         new
     }
 
+    /// Get a reference to the Vec, erasing the `N` const-generic
     pub const fn as_view(&self) -> &VecView<T> {
         self
     }
 
+    /// Get a `mut` reference to the Vec, erasing the `N` const-generic
     pub fn as_mut_view(&mut self) -> &mut VecView<T> {
         self
     }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -931,29 +931,40 @@ impl<T, const N: usize> Vec<T, N> {
         new
     }
 
-    /// Get a reference to the Vec, erasing the `N` const-generic
+    /// Get a reference to the `Vec`, erasing the `N` const-generic.
     ///
-    /// This can also be used through type coerction, since `Vec<T, N>` implements `Unsize<VecView<T>>`:
     ///
     /// ```rust
-    /// use heapless::{Vec, VecView};
-    ///
+    /// # use heapless::{Vec, VecView};
     /// let vec: Vec<u8, 10> = Vec::from_slice(&[1, 2, 3, 4]).unwrap();
-    /// let view: &VecView<_> = &vec;
+    /// let view: &VecView<u8> = vec.as_view();
+    /// ```
+    ///
+    /// It is often preferable to do the same through type coerction, since `Vec<T, N>` implements `Unsize<VecView<T>>`:
+    ///
+    /// ```rust
+    /// # use heapless::{Vec, VecView};
+    /// let vec: Vec<u8, 10> = Vec::from_slice(&[1, 2, 3, 4]).unwrap();
+    /// let view: &VecView<u8> = &vec;
     /// ```
     pub const fn as_view(&self) -> &VecView<T> {
         self
     }
 
-    /// Get a `mut` reference to the Vec, erasing the `N` const-generic
-    ///
-    /// This can also be used through type coerction, since `Vec<T, N>` implements `Unsize<VecView<T>>`:
+    /// Get a mutable reference to the `Vec`, erasing the `N` const-generic.
     ///
     /// ```rust
-    /// use heapless::{Vec, VecView};
-    ///
+    /// # use heapless::{Vec, VecView};
     /// let mut vec: Vec<u8, 10> = Vec::from_slice(&[1, 2, 3, 4]).unwrap();
-    /// let view: &mut VecView<_> = &mut vec;
+    /// let view: &mut VecView<u8> = vec.as_mut_view();
+    /// ```
+    ///
+    /// It is often preferable to do the same through type coerction, since `Vec<T, N>` implements `Unsize<VecView<T>>`:
+    ///
+    /// ```rust
+    /// # use heapless::{Vec, VecView};
+    /// let mut vec: Vec<u8, 10> = Vec::from_slice(&[1, 2, 3, 4]).unwrap();
+    /// let view: &mut VecView<u8> = &mut vec;
     /// ```
     pub fn as_mut_view(&mut self) -> &mut VecView<T> {
         self

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -65,7 +65,7 @@ pub struct VecInner<B: ?Sized + VecDrop> {
 /// assert_eq!(*vec, [7, 1, 2, 3]);
 /// ```
 ///
-/// In some cases, the const-generic might be cumbersome. `Vec` can coerce into a [`VecView`][] to remove the need for the const-generic:
+/// In some cases, the const-generic might be cumbersome. `Vec` can coerce into a [`VecView`](VecView) to remove the need for the const-generic:
 ///
 /// ```rust
 /// use heapless::{Vec, VecView};
@@ -77,9 +77,9 @@ pub type Vec<T, const N: usize> = VecInner<[MaybeUninit<T>; N]>;
 
 /// A Vec with dynamic capacity
 ///
-/// [`Vec`]() coerces to `VecView`. `VecView` is `!Sized`, meaning that it can only ever be used through pointer
+/// [`Vec`](Vec) coerces to `VecView`. `VecView` is `!Sized`, meaning that it can only ever be used through pointer
 ///
-/// Unlike [`Vec`](), `VecView` does not have an `N` const-generic parameter.
+/// Unlike [`Vec`](Vec), `VecView` does not have an `N` const-generic parameter.
 /// This has the ergonomic advantages of making it possible to use functions without needing to know at
 /// compile-time the size of the buffers used, for example for use in `dyn` traits.
 ///

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1203,7 +1203,6 @@ impl<T, const N: usize> Vec<T, N> {
     ///
     /// ```
     /// use heapless::Vec;
-    ///// use heapless::consts::*;
     ///
     /// let mut v: Vec<_, 8> = Vec::new();
     /// v.push("foo").unwrap();

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1973,8 +1973,6 @@ where
 
 // Implements Eq if underlying data is Eq
 impl<T, const N: usize> Eq for Vec<T, N> where T: Eq {}
-// Not sure about this one? Should two distinct capacities really be Eq?
-// Anyways it derefs to &[u8] which implements Eq so I suppose it should
 impl<T> Eq for VecView<T> where T: Eq {}
 
 impl<T, const N1: usize, const N2: usize> PartialOrd<Vec<T, N2>> for Vec<T, N1>

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -848,7 +848,6 @@ impl<T, const N: usize> Vec<T, N> {
     /// // allocate the vector in a static variable
     /// static mut X: Vec<u8, 16> = Vec::new();
     /// ```
-    /// `Vec` `const` constructor; wrap the returned value in [`Vec`].
     pub const fn new() -> Self {
         Self {
             len: 0,

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -65,7 +65,7 @@ pub struct VecInner<B: ?Sized + VecDrop> {
 /// assert_eq!(*vec, [7, 1, 2, 3]);
 /// ```
 ///
-/// In some cases, the const-generic might be cumbersome. `Vec` can coerce into a [`VecView`](VecView) to remove the need for the const-generic:
+/// In some cases, the const-generic might be cumbersome. `Vec` can coerce into a [`VecView`] to remove the need for the const-generic:
 ///
 /// ```rust
 /// use heapless::{Vec, VecView};
@@ -75,11 +75,11 @@ pub struct VecInner<B: ?Sized + VecDrop> {
 /// ```
 pub type Vec<T, const N: usize> = VecInner<[MaybeUninit<T>; N]>;
 
-/// A [`Vec`](Vec) with dynamic capacity
+/// A [`Vec`] with dynamic capacity
 ///
-/// [`Vec`](Vec) coerces to `VecView`. `VecView` is `!Sized`, meaning that it can only ever be used through pointer
+/// [`Vec`] coerces to `VecView`. `VecView` is `!Sized`, meaning that it can only ever be used through pointer
 ///
-/// Unlike [`Vec`](Vec), `VecView` does not have an `N` const-generic parameter.
+/// Unlike [`Vec`], `VecView` does not have an `N` const-generic parameter.
 /// This has the ergonomic advantages of making it possible to use functions without needing to know at
 /// compile-time the size of the buffers used, for example for use in `dyn` traits.
 ///

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -75,7 +75,7 @@ pub struct VecInner<B: ?Sized + VecDrop> {
 /// ```
 pub type Vec<T, const N: usize> = VecInner<[MaybeUninit<T>; N]>;
 
-/// A Vec with dynamic capacity
+/// A [`Vec`](Vec) with dynamic capacity
 ///
 /// [`Vec`](Vec) coerces to `VecView`. `VecView` is `!Sized`, meaning that it can only ever be used through pointer
 ///


### PR DESCRIPTION
Alternative approach to #424, with even better ergonomics and features, but slightly more confusing documentation.

```rust
use heapless::{Vec, VecView};

let mut vec: Vec<u8, 10> = Vec::from_slice(&[1, 2, 3, 4]).unwrap();
// No const-generic on the view, and `&Vec` coerces to `&VecView` through unsize coercion 
let view: &VecView<u8> = &vec;
assert_eq!(view, &[1, 2, 3, 4]);

// No const-generic on the view, and `&mut Vec` coerces to `&mut VecView` through unsize coercion 
let mut_view: &mut VecView<u8> = &mut vec;
mut_view.push(5);
assert_eq!(vec, [1, 2, 3, 4, 5]);
```

# Pros

This approach is more "scalable" in the sense that using it means that other structures that use a `Vec` internally can also have a `View` type that is simply the `!Sized` version of the same structure. This would be useful for the implementations of `String`,  `LinearMap`, `BinaryHeap`, and `heapless-bytes`.

This approach also enables implicit conversion between the owned type and the view without needing to make the owned type `Deref` to the view.

# Cons

The `Vec` and `VecView` types being aliases to a private type could be confusing.

Not totally sure about the semver compatibility of migrating to type alias for something that used to be a struct. Cargo semver-checks seems to complain.

---

Closes https://github.com/rust-embedded/heapless/pull/424.