### PR TITLE
`Vec` improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added `format` macro.
 - Added `String::from_utf16`.
+- Added `Vec::spare_capacity_mut`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `format` macro.
 - Added `String::from_utf16`.
 - Added `Vec::spare_capacity_mut`
+- Implemented `From<[T; N]>` for Vec
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `String::from_utf16`.
 - Added `Vec::spare_capacity_mut`
 - Implemented `From<[T; N]>` for Vec
+- Added `vec` macro for Vec
 
 ### Changed
 

--- a/src/sealed.rs
+++ b/src/sealed.rs
@@ -4,6 +4,11 @@ pub(crate) const fn smaller_than<const N: usize, const MAX: usize>() {
 }
 
 #[allow(dead_code, path_statements, clippy::no_effect)]
+pub(crate) const fn greater_than_eq<const N: usize, const MIN: usize>() {
+    Assert::<N, MIN>::GREATER_EQ;
+}
+
+#[allow(dead_code, path_statements, clippy::no_effect)]
 pub(crate) const fn greater_than_eq_0<const N: usize>() {
     Assert::<N, 0>::GREATER_EQ;
 }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1241,6 +1241,39 @@ where
     }
 }
 
+#[macro_export]
+/// Shorthand for defining vectors using array syntax.
+///
+/// Create `Vec` with a list of elements and capacity:
+/// ```
+/// let v = heapless::vec![1, 2, 3; 7];
+/// assert_eq!(v.as_slice(), &[1, 2, 3]);
+/// assert_eq!(v.capacity(), 7);
+/// ```
+///
+/// Create `Vec` with a repeated element, length, and capacity:
+/// ```
+/// let v = heapless::vec!['a'; 3; 4];
+/// assert_eq!(v.as_slice(), &['a', 'a', 'a']);
+/// assert_eq!(v.capacity(), 4);
+/// ```
+///
+/// Unlike the `std` version of this macro, the repeat element must be `Copy` or a constant, like
+/// with repeat elements in array expressions.
+macro_rules! vec {
+    (; $cap:expr) => {
+        heapless::Vec::<_, $cap>::new()
+    };
+
+    ($($elem:expr),+ ; $cap:expr) => {
+        heapless::Vec::<_, $cap>::from([$($elem),+])
+    };
+
+    ($elem:expr ; $len:expr ; $cap:expr) => {
+        heapless::Vec::<_, $cap>::from([$elem; $len])
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use crate::Vec;

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -888,6 +888,17 @@ impl<T, const N: usize> Drop for Vec<T, N> {
     }
 }
 
+impl<T, const N: usize> From<[T; N]> for Vec<T, N> {
+    /// Converts array to `Vec` of same size and capacity without copying
+    fn from(buffer: [T; N]) -> Self {
+        Self {
+            // cast [T; N] into [MaybeUninit<T>; N]
+            buffer: unsafe { buffer.as_ptr().cast::<[MaybeUninit<T>; N]>().read() },
+            len: N,
+        }
+    }
+}
+
 impl<'a, T: Clone, const N: usize> TryFrom<&'a [T]> for Vec<T, N> {
     type Error = ();
 


### PR DESCRIPTION
Add `spare_capacity_mut` and `From` implementation for `Vec`, as well as `vec!` macro.
Resolves #426 and #344