### PR TITLE
LinearMap: Fix false-positive clippy lint

### DIFF
--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -450,6 +450,9 @@ impl<'a, K, V> Iterator for Iter<'a, K, V> {
     type Item = (&'a K, &'a V);
 
     fn next(&mut self) -> Option<Self::Item> {
+        // False positive from clippy
+        // Option<&(K, V)> -> Option<(&K, &V)>
+        #[allow(clippy::map_identity)]
         self.iter.next().map(|(k, v)| (k, v))
     }
 }


### PR DESCRIPTION
False positive with 1.75.0