### PR TITLE
Add missing entries to list of implemented data structures in crate docs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed clippy lints.
 - Fixed `{arc,box,object}_pool!` emitting clippy lints for `CamelCase` and `SNAKE_CASE`.
+- Fixed the list of implemented data structures in the crate docs, by adding `Deque`,
+  `HistoryBuffer` and `SortedLinkedList` to the list.
 
 ## [v0.8.0] - 2023-11-07
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,8 @@
     doc = "- [`Box`](pool::boxed::Box) -- like `std::boxed::Box` but backed by a lock-free memory pool rather than `#[global_allocator]`"
 )]
 //! - [`BinaryHeap`] -- priority queue
+//! - [`Deque`] -- double-ended queue
+//! - [`HistoryBuffer`] -- similar to a write-only ring buffer
 //! - [`IndexMap`] -- hash table
 //! - [`IndexSet`] -- hash set
 //! - [`LinearMap`]
@@ -58,6 +60,7 @@
     any(arm_llsc, target_arch = "x86"),
     doc = "- [`Object`](pool::object::Object) -- objects managed by an object pool"
 )]
+//! - [`sorted_linked_list::SortedLinkedList`]
 //! - [`String`]
 //! - [`Vec`]
 //! - [`mpmc::Q*`](mpmc) -- multiple producer multiple consumer lock-free queue


### PR DESCRIPTION
Adds `Deque`, `HistoryBuffer` and `SortedLinkedList` to the list of implemented data structures in the crate docs. The current list of items seems to be only a subset what's actually been implemented.
