### PR TITLE
Only deny warnings in CI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: '-D warnings'
 
 jobs:
   # Run MIRI tests on nightly
@@ -111,7 +112,7 @@ jobs:
         with:
           components: clippy
           targets: i686-unknown-linux-musl
-      - run: cargo clippy --all --target i686-unknown-linux-musl --all-targets -- --deny warnings
+      - run: cargo clippy --all --target i686-unknown-linux-musl --all-targets
 
   # Compilation check
   check:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg), feature(doc_auto_cfg))]
 #![cfg_attr(not(test), no_std)]
 #![deny(missing_docs)]
-#![deny(warnings)]
 
 pub use binary_heap::BinaryHeap;
 pub use deque::Deque;


### PR DESCRIPTION
We already pass `--deny warnings` to `clippy`.