### PR TITLE
String: add `StringView`, similar to `VecView`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `VecView`, the `!Sized` version of `Vec`.
 - Added pool implementations for 64-bit architectures.
 - Added `IntoIterator` implementation for `LinearMap`
+- Added `StringView`, the `!Sized` version of `String`.
 
 ### Changed
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,8 +1,8 @@
 use core::hash::{BuildHasher, Hash};
 
 use crate::{
-    binary_heap::Kind as BinaryHeapKind, BinaryHeap, Deque, IndexMap, IndexSet, LinearMap, String,
-    Vec,
+    binary_heap::Kind as BinaryHeapKind, string::StringView, BinaryHeap, Deque, IndexMap, IndexSet,
+    LinearMap, String, Vec,
 };
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 
@@ -112,6 +112,15 @@ where
 }
 
 // String containers
+
+impl Serialize for StringView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&*self)
+    }
+}
 
 impl<const N: usize> Serialize for String<N> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/string.rs
+++ b/src/string.rs
@@ -246,7 +246,7 @@ impl<const N: usize> String<N> {
     ///
     /// let s: String<4> = String::try_from("ab")?;
     /// let b = s.into_bytes();
-    /// assert!(b.len() == 2);
+    /// assert_eq!(b.len(), 2);
     ///
     /// assert_eq!(&[b'a', b'b'], &b[..]);
     /// # Ok::<(), ()>(())
@@ -266,7 +266,7 @@ impl<const N: usize> String<N> {
     /// use heapless::String;
     ///
     /// let mut s: String<4> = String::try_from("ab")?;
-    /// assert!(s.as_str() == "ab");
+    /// assert_eq!(s.as_str(), "ab");
     ///
     /// let _s = s.as_str();
     /// // s.push('c'); // <- cannot borrow `s` as mutable because it is also borrowed as immutable
@@ -316,7 +316,7 @@ impl<const N: usize> String<N> {
     ///
     /// unsafe {
     ///     let vec = s.as_mut_vec();
-    ///     assert_eq!(&b"hello", &vec);
+    ///     assert_eq!(&vec, &b"hello");
     ///
     ///     vec.reverse();
     /// }
@@ -347,7 +347,7 @@ impl<const N: usize> String<N> {
     ///
     /// unsafe {
     ///     let vec = s.as_mut_vec_view();
-    ///     assert_eq!(&b"hello", &vec);
+    ///     assert_eq!(&vec, &b"hello");
     ///
     ///     vec.reverse();
     /// }
@@ -393,7 +393,7 @@ impl<const N: usize> String<N> {
     /// use heapless::String;
     ///
     /// let mut s: String<4> = String::new();
-    /// assert!(s.capacity() == 4);
+    /// assert_eq!(s.capacity(), 4);
     /// ```
     #[inline]
     pub fn capacity(&self) -> usize {
@@ -415,7 +415,7 @@ impl<const N: usize> String<N> {
     /// s.push('2').unwrap();
     /// s.push('3').unwrap();
     ///
-    /// assert!("abc123" == s.as_str());
+    /// assert_eq!("abc123", s.as_str());
     ///
     /// assert_eq!("abc123", s);
     /// # Ok::<(), ()>(())
@@ -449,7 +449,7 @@ impl<const N: usize> String<N> {
     ///
     /// s.truncate(2);
     ///
-    /// assert_eq!("he", s);
+    /// assert_eq!(s, "he");
     /// # Ok::<(), ()>(())
     /// ```
     #[inline]
@@ -548,7 +548,7 @@ impl StringView {
     ///
     /// let mut s: String<4> = String::try_from("ab")?;
     /// let s: &mut StringView = &mut s;
-    /// assert!(s.as_str() == "ab");
+    /// assert_eq!(s.as_str(), "ab");
     ///
     /// let _s = s.as_str();
     /// // s.push('c'); // <- cannot borrow `s` as mutable because it is also borrowed as immutable
@@ -600,7 +600,7 @@ impl StringView {
     ///
     /// unsafe {
     ///     let vec = s.as_mut_vec_view();
-    ///     assert_eq!(&b"hello", &vec);
+    ///     assert_eq!(&vec, &b"hello");
     ///
     ///     vec.reverse();
     /// }
@@ -625,7 +625,7 @@ impl StringView {
     ///
     /// assert!(s.push_str("bar").is_ok());
     ///
-    /// assert_eq!("foobar", s);
+    /// assert_eq!(s, "foobar");
     ///
     /// assert!(s.push_str("tender").is_err());
     /// # Ok::<(), ()>(())
@@ -647,7 +647,7 @@ impl StringView {
     ///
     /// let s: String<4> = String::new();
     /// let s: &StringView = &s;
-    /// assert!(s.capacity() == 4);
+    /// assert_eq!(s.capacity(), 4);
     /// ```
     #[inline]
     pub fn capacity(&self) -> usize {
@@ -670,9 +670,9 @@ impl StringView {
     /// s.push('2').unwrap();
     /// s.push('3').unwrap();
     ///
-    /// assert!("abc123" == s.as_str());
+    /// assert_eq!(s.as_str(), "abc123");
     ///
-    /// assert_eq!("abc123", s);
+    /// assert_eq!(s, "abc123");
     /// # Ok::<(), ()>(())
     /// ```
     #[inline]
@@ -1199,7 +1199,7 @@ mod tests {
     #[test]
     fn empty() {
         let s: String<4> = String::new();
-        assert!(s.capacity() == 4);
+        assert_eq!(s.capacity(), 4);
         assert_eq!(s, "");
         assert_eq!(s.len(), 0);
         assert_ne!(s.len(), 4);
@@ -1208,7 +1208,7 @@ mod tests {
     #[test]
     fn try_from() {
         let s: String<4> = String::try_from("123").unwrap();
-        assert!(s.len() == 3);
+        assert_eq!(s.len(), 3);
         assert_eq!(s, "123");
 
         let _: () = String::<2>::try_from("123").unwrap_err();
@@ -1219,7 +1219,7 @@ mod tests {
         use core::str::FromStr;
 
         let s: String<4> = String::<4>::from_str("123").unwrap();
-        assert!(s.len() == 3);
+        assert_eq!(s.len(), 3);
         assert_eq!(s, "123");
 
         let _: () = String::<2>::from_str("123").unwrap_err();
@@ -1297,7 +1297,7 @@ mod tests {
         assert!(s.push('2').is_ok());
         assert!(s.push('3').is_ok());
         assert!(s.push('4').is_err());
-        assert!("abc123" == s.as_str());
+        assert_eq!("abc123", s.as_str());
     }
 
     #[test]

--- a/src/string.rs
+++ b/src/string.rs
@@ -94,6 +94,44 @@ impl<const N: usize> String<N> {
         Self { vec: Vec::new() }
     }
 
+    /// Get a reference to the `String`, erasing the `N` const-generic.
+    ///
+    /// ```rust
+    /// # use heapless::string::{String, StringView};
+    /// let s: String<12> = String::try_from("Hello").unwrap();
+    /// let view: &StringView = s.as_view();
+    /// ```
+    ///
+    /// It is often preferable to do the same through type coerction, since `String<N>` implements `Unsize<StringView>`:
+    ///
+    /// ```rust
+    /// # use heapless::string::{String, StringView};
+    /// let s: String<12> = String::try_from("Hello").unwrap();
+    /// let view: &StringView  = &s;
+    /// ```
+    pub fn as_view(&self) -> &StringView {
+        self
+    }
+
+    /// Get a mutable reference to the `String`, erasing the `N` const-generic.
+    ///
+    /// ```rust
+    /// # use heapless::string::{String, StringView};
+    /// let mut s: String<12> = String::try_from("Hello").unwrap();
+    /// let view: &mut StringView = s.as_mut_view();
+    /// ```
+    ///
+    /// It is often preferable to do the same through type coerction, since `String<N>` implements `Unsize<StringView>`:
+    ///
+    /// ```rust
+    /// # use heapless::string::{String, StringView};
+    /// let mut s: String<12> = String::try_from("Hello").unwrap();
+    /// let view: &mut StringView  = &mut s;
+    /// ```
+    pub fn as_mut_view(&mut self) -> &mut StringView {
+        self
+    }
+
     /// Decodes a UTF-16–encoded slice `v` into a `String`, returning [`Err`]
     /// if `v` contains any invalid data.
     ///

--- a/src/string.rs
+++ b/src/string.rs
@@ -107,7 +107,7 @@ impl<const N: usize> String<N> {
     /// ```rust
     /// # use heapless::string::{String, StringView};
     /// let s: String<12> = String::try_from("Hello").unwrap();
-    /// let view: &StringView  = &s;
+    /// let view: &StringView = &s;
     /// ```
     pub fn as_view(&self) -> &StringView {
         self
@@ -126,7 +126,7 @@ impl<const N: usize> String<N> {
     /// ```rust
     /// # use heapless::string::{String, StringView};
     /// let mut s: String<12> = String::try_from("Hello").unwrap();
-    /// let view: &mut StringView  = &mut s;
+    /// let view: &mut StringView = &mut s;
     /// ```
     pub fn as_mut_view(&mut self) -> &mut StringView {
         self
@@ -590,7 +590,7 @@ impl StringView {
     /// Basic usage:
     ///
     /// ```
-    /// use heapless::string::{String,StringView};
+    /// use heapless::string::{String, StringView};
     ///
     /// let mut s: String<8> = String::try_from("hello")?;
     /// let s: &mut StringView = &mut s;
@@ -615,7 +615,7 @@ impl StringView {
     /// Basic usage:
     ///
     /// ```
-    /// use heapless::string::{String,StringView};
+    /// use heapless::string::{String, StringView};
     ///
     /// let mut s: String<8> = String::try_from("foo")?;
     /// let s: &mut StringView = &mut s;
@@ -640,7 +640,7 @@ impl StringView {
     /// Basic usage:
     ///
     /// ```
-    /// use heapless::string::{String,StringView};
+    /// use heapless::string::{String, StringView};
     ///
     /// let s: String<4> = String::new();
     /// let s: &StringView = &s;
@@ -658,7 +658,7 @@ impl StringView {
     /// Basic usage:
     ///
     /// ```
-    /// use heapless::string::{String,StringView};
+    /// use heapless::string::{String, StringView};
     ///
     /// let mut s: String<8> = String::try_from("abc")?;
     /// let s: &mut StringView = &mut s;
@@ -700,7 +700,7 @@ impl StringView {
     /// Basic usage:
     ///
     /// ```
-    /// use heapless::string::{String,StringView};
+    /// use heapless::string::{String, StringView};
     ///
     /// let mut s: String<8> = String::try_from("hello")?;
     /// let s: &mut StringView = &mut s;
@@ -727,7 +727,7 @@ impl StringView {
     /// Basic usage:
     ///
     /// ```
-    /// use heapless::string::{String,StringView};
+    /// use heapless::string::{String, StringView};
     ///
     /// let mut s: String<8> = String::try_from("foo")?;
     /// let s: &mut StringView = &mut s;
@@ -767,7 +767,7 @@ impl StringView {
     /// Basic usage:
     ///
     /// ```
-    /// use heapless::string::{String,StringView};
+    /// use heapless::string::{String, StringView};
     ///
     /// let mut s: String<8> = String::try_from("foo").unwrap();
     /// let s: &mut StringView = &mut s;

--- a/src/string.rs
+++ b/src/string.rs
@@ -314,7 +314,7 @@ impl<const N: usize> String<N> {
     ///
     /// unsafe {
     ///     let vec = s.as_mut_vec();
-    ///     assert_eq!(&[104, 101, 108, 108, 111][..], &vec[..]);
+    ///     assert_eq!(&b"hello", &vec);
     ///
     ///     vec.reverse();
     /// }
@@ -322,6 +322,37 @@ impl<const N: usize> String<N> {
     /// # Ok::<(), ()>(())
     /// ```
     pub unsafe fn as_mut_vec(&mut self) -> &mut Vec<u8, N> {
+        &mut self.vec
+    }
+
+    /// Returns a mutable reference to the contents of this `String`.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because it does not check that the bytes passed
+    /// to it are valid UTF-8. If this constraint is violated, it may cause
+    /// memory unsafety issues with future users of the `String`, as the rest of
+    /// the library assumes that `String`s are valid UTF-8.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use heapless::String;
+    ///
+    /// let mut s: String<8> = String::try_from("hello")?;
+    ///
+    /// unsafe {
+    ///     let vec = s.as_mut_vec_view();
+    ///     assert_eq!(&b"hello", &vec);
+    ///
+    ///     vec.reverse();
+    /// }
+    /// assert_eq!(s, "olleh");
+    /// # Ok::<(), ()>(())
+    /// ```
+    pub unsafe fn as_mut_vec_view(&mut self) -> &mut VecView<u8> {
         &mut self.vec
     }
 
@@ -592,7 +623,7 @@ impl StringView {
     ///
     /// unsafe {
     ///     let vec = s.as_mut_vec();
-    ///     assert_eq!(&[104, 101, 108, 108, 111][..], &vec[..]);
+    ///     assert_eq!(&b"hello", &vec);
     ///
     ///     vec.reverse();
     /// }

--- a/src/string.rs
+++ b/src/string.rs
@@ -541,9 +541,10 @@ impl StringView {
     /// Basic usage:
     ///
     /// ```
-    /// use heapless::String;
+    /// use heapless::string::{String, StringView};
     ///
     /// let mut s: String<4> = String::try_from("ab")?;
+    /// let s: &mut StringView = &mut s;
     /// assert!(s.as_str() == "ab");
     ///
     /// let _s = s.as_str();
@@ -562,9 +563,10 @@ impl StringView {
     /// Basic usage:
     ///
     /// ```
-    /// use heapless::String;
+    /// use heapless::string::{String, StringView};
     ///
     /// let mut s: String<4> = String::try_from("ab")?;
+    /// let s: &mut StringView = &mut s;
     /// let s = s.as_mut_str();
     /// s.make_ascii_uppercase();
     /// # Ok::<(), ()>(())
@@ -588,12 +590,13 @@ impl StringView {
     /// Basic usage:
     ///
     /// ```
-    /// use heapless::String;
+    /// use heapless::string::{String,StringView};
     ///
     /// let mut s: String<8> = String::try_from("hello")?;
+    /// let s: &mut StringView = &mut s;
     ///
     /// unsafe {
-    ///     let vec = s.as_mut_vec();
+    ///     let vec = s.as_mut_vec_view();
     ///     assert_eq!(&b"hello", &vec);
     ///
     ///     vec.reverse();
@@ -612,9 +615,10 @@ impl StringView {
     /// Basic usage:
     ///
     /// ```
-    /// use heapless::String;
+    /// use heapless::string::{String,StringView};
     ///
     /// let mut s: String<8> = String::try_from("foo")?;
+    /// let s: &mut StringView = &mut s;
     ///
     /// assert!(s.push_str("bar").is_ok());
     ///
@@ -636,9 +640,10 @@ impl StringView {
     /// Basic usage:
     ///
     /// ```
-    /// use heapless::String;
+    /// use heapless::string::{String,StringView};
     ///
-    /// let mut s: String<4> = String::new();
+    /// let s: String<4> = String::new();
+    /// let s: &StringView = &s;
     /// assert!(s.capacity() == 4);
     /// ```
     #[inline]
@@ -653,9 +658,10 @@ impl StringView {
     /// Basic usage:
     ///
     /// ```
-    /// use heapless::String;
+    /// use heapless::string::{String,StringView};
     ///
     /// let mut s: String<8> = String::try_from("abc")?;
+    /// let s: &mut StringView = &mut s;
     ///
     /// s.push('1').unwrap();
     /// s.push('2').unwrap();
@@ -694,9 +700,10 @@ impl StringView {
     /// Basic usage:
     ///
     /// ```
-    /// use heapless::String;
+    /// use heapless::string::{String,StringView};
     ///
     /// let mut s: String<8> = String::try_from("hello")?;
+    /// let s: &mut StringView = &mut s;
     ///
     /// s.truncate(2);
     ///
@@ -720,9 +727,10 @@ impl StringView {
     /// Basic usage:
     ///
     /// ```
-    /// use heapless::String;
+    /// use heapless::string::{String,StringView};
     ///
     /// let mut s: String<8> = String::try_from("foo")?;
+    /// let s: &mut StringView = &mut s;
     ///
     /// assert_eq!(s.pop(), Some('o'));
     /// assert_eq!(s.pop(), Some('o'));
@@ -759,9 +767,10 @@ impl StringView {
     /// Basic usage:
     ///
     /// ```
-    /// use heapless::String;
+    /// use heapless::string::{String,StringView};
     ///
     /// let mut s: String<8> = String::try_from("foo").unwrap();
+    /// let s: &mut StringView = &mut s;
     ///
     /// assert_eq!(s.remove(0), 'f');
     /// assert_eq!(s.remove(1), 'o');
@@ -794,9 +803,10 @@ impl StringView {
     /// Basic usage:
     ///
     /// ```
-    /// use heapless::String;
+    /// use heapless::string::{String, StringView};
     ///
     /// let mut s: String<8> = String::try_from("foo")?;
+    /// let s: &mut StringView = &mut s;
     ///
     /// s.clear();
     ///

--- a/src/string.rs
+++ b/src/string.rs
@@ -109,6 +109,7 @@ impl<const N: usize> String<N> {
     /// let s: String<12> = String::try_from("Hello").unwrap();
     /// let view: &StringView = &s;
     /// ```
+    #[inline]
     pub fn as_view(&self) -> &StringView {
         self
     }
@@ -128,6 +129,7 @@ impl<const N: usize> String<N> {
     /// let mut s: String<12> = String::try_from("Hello").unwrap();
     /// let view: &mut StringView = &mut s;
     /// ```
+    #[inline]
     pub fn as_mut_view(&mut self) -> &mut StringView {
         self
     }
@@ -352,6 +354,7 @@ impl<const N: usize> String<N> {
     /// assert_eq!(s, "olleh");
     /// # Ok::<(), ()>(())
     /// ```
+    #[inline]
     pub unsafe fn as_mut_vec_view(&mut self) -> &mut VecView<u8> {
         self.as_mut_view().as_mut_vec_view()
     }


### PR DESCRIPTION
Follow up of #425 

This time we need a dedicated `sealed` module for `StringInner`, because of the `pub mod string` in `lib.rs`. Maybe `VecInner` should have the same treatment, in case some time in the future the `vec` module is made public.