### PR TITLE
Add DequeView, similar to VecView and StringView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `VecView`, the `!Sized` version of `Vec`.
 - Added pool implementations for 64-bit architectures.
 - Added `IntoIterator` implementation for `LinearMap`
+- Added `DequeView`, the `!Sized` version of `Deque`.
 
 ### Changed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@
 )]
 
 pub use binary_heap::BinaryHeap;
-pub use deque::Deque;
+pub use deque::{Deque, DequeView};
 pub use histbuf::{HistoryBuffer, OldestOrdered};
 pub use indexmap::{
     Bucket, Entry, FnvIndexMap, IndexMap, Iter as IndexMapIter, IterMut as IndexMapIterMut,
@@ -102,7 +102,11 @@ pub use string::String;
 // doc(hidden) prevents the `pub use vec::VecInner` from being visible in the documentation.
 #[cfg(doc)]
 #[doc(hidden)]
+pub use deque::DequeInner as _;
+#[cfg(doc)]
+#[doc(hidden)]
 pub use vec::VecInner as _;
+
 pub use vec::{Vec, VecView};
 
 #[macro_use]

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,8 +1,8 @@
 use core::hash::{BuildHasher, Hash};
 
 use crate::{
-    binary_heap::Kind as BinaryHeapKind, BinaryHeap, Deque, IndexMap, IndexSet, LinearMap, String,
-    Vec,
+    binary_heap::Kind as BinaryHeapKind, BinaryHeap, Deque, DequeView, IndexMap, IndexSet,
+    LinearMap, String, Vec,
 };
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 
@@ -59,6 +59,22 @@ where
 }
 
 impl<T, const N: usize> Serialize for Deque<T, N>
+where
+    T: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(self.len()))?;
+        for element in self {
+            seq.serialize_element(element)?;
+        }
+        seq.end()
+    }
+}
+
+impl<T> Serialize for DequeView<T>
 where
     T: Serialize,
 {


### PR DESCRIPTION
Ideally we would be able to merge the iterators of `&(mut) DequeView` and `&(mut) Deque`, but this can't be done without a breaking change.