### PR TITLE
Add `uDisplay` for `String` and inline `ufmt` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Implemented `PartialEq` and `Eq` for `Deque`.
 - Added `truncate` to `IndexMap`.
 - Added `get_index` and `get_index_mut` to `IndexMap`.
+- Added `String::uDisplay`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - `ufmt-impl` is now `ufmt`
   - `cas` is removed, atomic polyfilling is now opt-in via the `portable-atomic` feature.
 - `Vec::as_mut_slice` is now a public method.
+- `ufmt` functions are annotated with `inline`.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,13 +47,13 @@ hash32 = "0.3.0"
 serde = { version = "1", optional = true, default-features = false }
 ufmt-write = { version = "0.1", optional = true }
 defmt = { version = "1.0.1", optional = true }
+ufmt = "0.2"
 
 # for the pool module
 [target.'cfg(any(target_arch = "arm", target_pointer_width = "32", target_pointer_width = "64"))'.dependencies]
 stable_deref_trait = { version = "1", default-features = false }
 
 [dev-dependencies]
-ufmt = "0.2"
 static_assertions = "1.1.0"
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ portable-atomic-unsafe-assume-single-core = ["dep:portable-atomic", "portable-at
 serde = ["dep:serde"]
 
 # implement ufmt traits.
-ufmt = ["dep:ufmt-write"]
+ufmt = ["dep:ufmt", "dep:ufmt-write"]
 
 # Implement `defmt::Format`.
 defmt = ["dep:defmt"]
@@ -45,9 +45,9 @@ nightly = []
 portable-atomic = { version = "1.0", optional = true }
 hash32 = "0.3.0"
 serde = { version = "1", optional = true, default-features = false }
+ufmt = { version = "0.2", optional = true }
 ufmt-write = { version = "0.1", optional = true }
 defmt = { version = "1.0.1", optional = true }
-ufmt = "0.2"
 
 # for the pool module
 [target.'cfg(any(target_arch = "arm", target_pointer_width = "32", target_pointer_width = "64"))'.dependencies]

--- a/src/ufmt.rs
+++ b/src/ufmt.rs
@@ -7,6 +7,7 @@ use ufmt::uDisplay;
 use ufmt_write::uWrite;
 
 impl<S: StringStorage + ?Sized> uDisplay for StringInner<S> {
+    #[inline]
     fn fmt<W>(&self, f: &mut ufmt::Formatter<'_, W>) -> Result<(), W::Error>
     where
         W: uWrite + ?Sized,
@@ -17,6 +18,7 @@ impl<S: StringStorage + ?Sized> uDisplay for StringInner<S> {
 
 impl<S: StringStorage + ?Sized> uWrite for StringInner<S> {
     type Error = CapacityError;
+    #[inline]
     fn write_str(&mut self, s: &str) -> Result<(), Self::Error> {
         self.push_str(s)
     }
@@ -24,6 +26,7 @@ impl<S: StringStorage + ?Sized> uWrite for StringInner<S> {
 
 impl<S: VecStorage<u8> + ?Sized> uWrite for VecInner<u8, S> {
     type Error = CapacityError;
+    #[inline]
     fn write_str(&mut self, s: &str) -> Result<(), Self::Error> {
         self.extend_from_slice(s.as_bytes())
     }

--- a/src/ufmt.rs
+++ b/src/ufmt.rs
@@ -3,7 +3,17 @@ use crate::{
     vec::{VecInner, VecStorage},
     CapacityError,
 };
+use ufmt::uDisplay;
 use ufmt_write::uWrite;
+
+impl<S: StringStorage + ?Sized> uDisplay for StringInner<S> {
+    fn fmt<W>(&self, f: &mut ufmt::Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        f.write_str(&self.as_str())
+    }
+}
 
 impl<S: StringStorage + ?Sized> uWrite for StringInner<S> {
     type Error = CapacityError;
@@ -32,7 +42,16 @@ mod tests {
     }
 
     #[test]
-    fn test_string() {
+    fn test_udisplay_string() {
+        let str_a = String::<32>::try_from("world").unwrap();
+        let mut str_b = String::<32>::new();
+        uwrite!(str_b, "Hello {}!", str_a).unwrap();
+
+        assert_eq!(str_b, "Hello world!");
+    }
+
+    #[test]
+    fn test_uwrite_string() {
         let a = 123;
         let b = Pair { x: 0, y: 1234 };
 
@@ -43,14 +62,14 @@ mod tests {
     }
 
     #[test]
-    fn test_string_err() {
+    fn test_uwrite_string_err() {
         let p = Pair { x: 0, y: 1234 };
         let mut s = String::<4>::new();
         assert!(uwrite!(s, "{:?}", p).is_err());
     }
 
     #[test]
-    fn test_vec() {
+    fn test_uwrite_vec() {
         let a = 123;
         let b = Pair { x: 0, y: 1234 };
 


### PR DESCRIPTION
Most likely the compiler already inlines the function calls, but afaik adding the annotation makes it more likely.

I could not build it locally due to:
```
   Compiling heapless v0.8.0 (/home/lucas/repos/heapless)
error[E0658]: use of unstable library feature 'build_hasher_simple_hash_one'
    --> src/indexmap.rs:1260:28
     |
1260 |     HashValue(build_hasher.hash_one(key) as u16)
     |                            ^^^^^^^^
     |
     = note: see issue #86161 <https://github.com/rust-lang/rust/issues/86161> for more information

For more information about this error, try `rustc --explain E0658`.
error: could not compile `heapless` due to previous error
```
But the implementation seems trivial and has been tested elsewhere.
I did not add `uDisplay` for `Vec` because the formatting is not trivial.

We might want to consider adding `uDebug`, but don't know what the rusty way to do so would be.