### PR TITLE
Fix `MpMcQueue` with `mpmc_large` feature.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed `{arc,box,object}_pool!` emitting clippy lints.
 - Fixed the list of implemented data structures in the crate docs, by adding `Deque`,
   `HistoryBuffer` and `SortedLinkedList` to the list.
+- Fixed `MpMcQueue` with `mpmc_large` feature.
 
 ## [v0.8.0] - 2023-11-07
 


### PR DESCRIPTION
Fixes https://github.com/rust-embedded/heapless/issues/461.