### PR TITLE
Add std `Entry` methods to indexmap `Entry`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `Vec::drain`.
 - Added `String::drain`.
 - Implemented `DoubleEndedIterator` for `OldestOrdered`.
+- Added std `Entry` methods to indexmap `Entry`.
 
 ### Changed
 


### PR DESCRIPTION
## Description

It would be nice to have some methods for `Entry` like std HashMap [`Entry`](https://doc.rust-lang.org/std/collections/hash_map/enum.Entry.html#implementations) so that developer can using chained method calls.