### PR TITLE
LinearMap: add `LinearMapView`, similar to `VecView`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `VecView`, the `!Sized` version of `Vec`.
 - Added pool implementations for 64-bit architectures.
 - Added `IntoIterator` implementation for `LinearMap`
+- Added `LinearMapView`, the `!Sized` version of `LinearMap`.
 
 ### Changed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ pub use indexmap::{
     ValuesMut as IndexMapValuesMut,
 };
 pub use indexset::{FnvIndexSet, IndexSet, Iter as IndexSetIter};
-pub use linear_map::LinearMap;
+pub use linear_map::{LinearMap, LinearMapView};
 pub use string::String;
 
 // Workaround https://github.com/rust-lang/rust/issues/119015. This is required so that the methods on `VecView` and `Vec` are properly documented.

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -1,14 +1,47 @@
 use core::{borrow::Borrow, fmt, mem, ops, slice};
 
-use crate::Vec;
+use crate::{Vec, VecView};
+
+mod sealed {
+    /// <div class="warn">This is private API and should not be used</div>
+    pub struct LinearMapInner<V: ?Sized> {
+        pub(super) buffer: V,
+    }
+}
+
+// Workaround https://github.com/rust-lang/rust/issues/119015. This is required so that the methods on `VecView` and `Vec` are properly documented.
+// cfg(doc) prevents `StringInner` being part of the public API.
+// doc(hidden) prevents the `pub use sealed::StringInner` from being visible in the documentation.
+#[cfg(doc)]
+#[doc(hidden)]
+pub use sealed::LinearMapInner as _;
 
 /// A fixed capacity map/dictionary that performs lookups via linear search.
 ///
 /// Note that as this map doesn't use hashing so most operations are *O*(n) instead of *O*(1).
+pub type LinearMap<K, V, const N: usize> = sealed::LinearMapInner<Vec<(K, V), N>>;
 
-pub struct LinearMap<K, V, const N: usize> {
-    pub(crate) buffer: Vec<(K, V), N>,
-}
+/// A [`LinearMap`] with dynamic capacity
+///
+/// [`LinearMap`] coerces to `LinearMapView`. `LinearMapView` is `!Sized`, meaning it can only ever be used by reference
+///
+/// Unlike [`LinearMap`], `LinearMapView` does not have an `N` const-generic parameter.
+/// This has the ergonomic advantage of making it possible to use functions without needing to know at
+/// compile-time the size of the buffers used, for example for use in `dyn` traits.
+///
+/// `LinearMapView` is to `LinearMap` what [`VecView`] is to [`Vec`].
+///
+/// ```rust
+/// use heapless::LinearMap;
+///
+/// let mut map: LinearMap<_, _, 8> = LinearMap::new();
+/// map.insert(1, "a").unwrap();
+/// if let Some(x) = map.get_mut(&1) {
+///     *x = "b";
+/// }
+/// assert_eq!(map[&1], "b");
+/// ```
+pub type LinearMapView<K, V> = sealed::LinearMapInner<VecView<(K, V)>>;
 
 impl<K, V, const N: usize> LinearMap<K, V, N> {
     /// Creates an empty `LinearMap`.
@@ -16,13 +49,16 @@ impl<K, V, const N: usize> LinearMap<K, V, N> {
     /// # Examples
     ///
     /// ```
-    /// use heapless::LinearMap;
+    /// use heapless::{LinearMap, LinearMapView};
     ///
     /// // allocate the map on the stack
     /// let mut map: LinearMap<&str, isize, 8> = LinearMap::new();
     ///
     /// // allocate the map in a static variable
     /// static mut MAP: LinearMap<&str, isize, 8> = LinearMap::new();
+    ///
+    /// // allocate the map in a static variable, erasing the const generic
+    /// static mut MAP_VIEW: &mut LinearMapView<&str, isize> = &mut LinearMap::<_, _, 8>::new();
     /// ```
     pub const fn new() -> Self {
         Self { buffer: Vec::new() }
@@ -399,6 +435,369 @@ where
     }
 }
 
+impl<K, V> LinearMapView<K, V>
+where
+    K: Eq,
+{
+    /// Returns the number of elements that the map can hold.
+    ///
+    /// Computes in *O*(1) time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use heapless::{LinearMap, LinearMapView};
+    ///
+    /// let map: LinearMap<&str, isize, 8> = LinearMap::new();
+    /// let map_view: &LinearMapView<&str, isize> = &map;
+    /// assert_eq!(map_view.capacity(), 8);
+    /// ```
+    pub fn capacity(&self) -> usize {
+        self.buffer.capacity()
+    }
+
+    /// Clears the map, removing all key-value pairs.
+    ///
+    /// Computes in *O*(1) time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use heapless::{LinearMapView, LinearMap};
+    ///
+    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
+    /// let map_view: &mut LinearMapView<_, _> = &mut map;
+    /// map_view.insert(1, "a").unwrap();
+    /// map_view.clear();
+    /// assert!(map_view.is_empty());
+    /// ```
+    pub fn clear(&mut self) {
+        self.buffer.clear()
+    }
+
+    /// Returns true if the map contains a value for the specified key.
+    ///
+    /// Computes in *O*(n) time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use heapless::{LinearMap, LinearMapView};
+    ///
+    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
+    /// let map_view: &mut LinearMapView<_, _> = &mut map;
+    /// map_view.insert(1, "a").unwrap();
+    /// assert_eq!(map_view.contains_key(&1), true);
+    /// assert_eq!(map_view.contains_key(&2), false);
+    /// ```
+    pub fn contains_key(&self, key: &K) -> bool {
+        self.get(key).is_some()
+    }
+
+    /// Returns a reference to the value corresponding to the key.
+    ///
+    /// Computes in *O*(n) time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use heapless::{LinearMap, LinearMapView};
+    ///
+    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
+    /// let map_view: &mut LinearMapView<_, _> = &mut map;
+    /// map_view.insert(1, "a").unwrap();
+    /// assert_eq!(map_view.get(&1), Some(&"a"));
+    /// assert_eq!(map_view.get(&2), None);
+    /// ```
+    pub fn get<Q>(&self, key: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: Eq + ?Sized,
+    {
+        self.iter()
+            .find(|&(k, _)| k.borrow() == key)
+            .map(|(_, v)| v)
+    }
+
+    /// Returns a mutable reference to the value corresponding to the key.
+    ///
+    /// Computes in *O*(n) time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use heapless::{LinearMap, LinearMapView};
+    ///
+    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
+    /// let map_view: &mut LinearMapView<_, _> = &mut map;
+    /// map_view.insert(1, "a").unwrap();
+    /// if let Some(x) = map_view.get_mut(&1) {
+    ///     *x = "b";
+    /// }
+    /// assert_eq!(map_view[&1], "b");
+    /// ```
+    pub fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
+    where
+        K: Borrow<Q>,
+        Q: Eq + ?Sized,
+    {
+        self.iter_mut()
+            .find(|&(k, _)| k.borrow() == key)
+            .map(|(_, v)| v)
+    }
+
+    /// Returns the number of elements in this map.
+    ///
+    /// Computes in *O*(1) time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use heapless::{LinearMap, LinearMapView};
+    ///
+    /// let mut a: LinearMap<_, _, 8> = LinearMap::new();
+    /// let mut a_view: &mut LinearMapView<_, _> = &mut a;
+    /// assert_eq!(a_view.len(), 0);
+    /// a_view.insert(1, "a").unwrap();
+    /// assert_eq!(a_view.len(), 1);
+    /// ```
+    pub fn len(&self) -> usize {
+        self.buffer.len()
+    }
+
+    /// Inserts a key-value pair into the map.
+    ///
+    /// If the map did not have this key present, `None` is returned.
+    ///
+    /// If the map did have this key present, the value is updated, and the old value is returned.
+    ///
+    /// Computes in *O*(n) time
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use heapless::{LinearMap, LinearMapView};
+    ///
+    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
+    /// let map_view: &mut LinearMapView<_, _> = &mut map;
+    /// assert_eq!(map_view.insert(37, "a").unwrap(), None);
+    /// assert_eq!(map_view.is_empty(), false);
+    ///
+    /// map_view.insert(37, "b").unwrap();
+    /// assert_eq!(map_view.insert(37, "c").unwrap(), Some("b"));
+    /// assert_eq!(map_view[&37], "c");
+    /// ```
+    pub fn insert(&mut self, key: K, mut value: V) -> Result<Option<V>, (K, V)> {
+        if let Some((_, v)) = self.iter_mut().find(|&(k, _)| *k == key) {
+            mem::swap(v, &mut value);
+            return Ok(Some(value));
+        }
+
+        self.buffer.push((key, value))?;
+        Ok(None)
+    }
+
+    /// Returns true if the map contains no elements.
+    ///
+    /// Computes in *O*(1) time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use heapless::{LinearMap, LinearMapView};
+    ///
+    /// let mut a: LinearMap<_, _, 8> = LinearMap::new();
+    /// let a_view: &mut LinearMapView<_, _> = &mut a;
+    /// assert!(a_view.is_empty());
+    /// a_view.insert(1, "a").unwrap();
+    /// assert!(!a_view.is_empty());
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// An iterator visiting all key-value pairs in arbitrary order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use heapless::{LinearMap, LinearMapView};
+    ///
+    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
+    /// let map_view: &mut LinearMapView<_, _> = &mut map;
+    /// map_view.insert("a", 1).unwrap();
+    /// map_view.insert("b", 2).unwrap();
+    /// map_view.insert("c", 3).unwrap();
+    ///
+    /// for (key, val) in map_view.iter() {
+    ///     println!("key: {} val: {}", key, val);
+    /// }
+    /// ```
+    pub fn iter(&self) -> Iter<'_, K, V> {
+        Iter {
+            iter: self.buffer.as_slice().iter(),
+        }
+    }
+
+    /// An iterator visiting all key-value pairs in arbitrary order,
+    /// with mutable references to the values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use heapless::{LinearMap, LinearMapView};
+    ///
+    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
+    /// let map_view: &mut LinearMapView<_, _> = &mut map;
+    /// map_view.insert("a", 1).unwrap();
+    /// map_view.insert("b", 2).unwrap();
+    /// map_view.insert("c", 3).unwrap();
+    ///
+    /// // Update all values
+    /// for (_, val) in map_view.iter_mut() {
+    ///     *val = 2;
+    /// }
+    ///
+    /// for (key, val) in &*map_view {
+    ///     println!("key: {} val: {}", key, val);
+    /// }
+    /// ```
+    pub fn iter_mut(&mut self) -> IterMut<'_, K, V> {
+        IterMut {
+            iter: self.buffer.as_mut_slice().iter_mut(),
+        }
+    }
+
+    /// An iterator visiting all keys in arbitrary order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use heapless::{LinearMap, LinearMapView};
+    ///
+    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
+    /// let map_view: &mut LinearMapView<_, _> = &mut map;
+    /// map_view.insert("a", 1).unwrap();
+    /// map_view.insert("b", 2).unwrap();
+    /// map_view.insert("c", 3).unwrap();
+    ///
+    /// for key in map_view.keys() {
+    ///     println!("{}", key);
+    /// }
+    /// ```
+    pub fn keys(&self) -> impl Iterator<Item = &K> {
+        self.iter().map(|(k, _)| k)
+    }
+
+    /// Removes a key from the map, returning the value at
+    /// the key if the key was previously in the map.
+    ///
+    /// Computes in *O*(n) time
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use heapless::{LinearMap, LinearMapView};
+    ///
+    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
+    /// let map_view: &mut LinearMapView<_, _> = &mut map;
+    /// map_view.insert(1, "a").unwrap();
+    /// assert_eq!(map_view.remove(&1), Some("a"));
+    /// assert_eq!(map_view.remove(&1), None);
+    /// ```
+    pub fn remove<Q>(&mut self, key: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: Eq + ?Sized,
+    {
+        let idx = self
+            .keys()
+            .enumerate()
+            .find(|&(_, k)| k.borrow() == key)
+            .map(|(idx, _)| idx);
+
+        idx.map(|idx| self.buffer.swap_remove(idx).1)
+    }
+
+    /// An iterator visiting all values in arbitrary order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use heapless::{LinearMap, LinearMapView};
+    ///
+    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
+    /// let map_view: &mut LinearMapView<_, _> = &mut map;
+    /// map_view.insert("a", 1).unwrap();
+    /// map_view.insert("b", 2).unwrap();
+    /// map_view.insert("c", 3).unwrap();
+    ///
+    /// for val in map_view.values() {
+    ///     println!("{}", val);
+    /// }
+    /// ```
+    pub fn values(&self) -> impl Iterator<Item = &V> {
+        self.iter().map(|(_, v)| v)
+    }
+
+    /// An iterator visiting all values mutably in arbitrary order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use heapless::{LinearMap, LinearMapView};
+    ///
+    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
+    /// let map_view: &mut LinearMapView<_, _> = &mut map;
+    /// map_view.insert("a", 1).unwrap();
+    /// map_view.insert("b", 2).unwrap();
+    /// map_view.insert("c", 3).unwrap();
+    ///
+    /// for val in map_view.values_mut() {
+    ///     *val += 10;
+    /// }
+    ///
+    /// for val in map_view.values() {
+    ///     println!("{}", val);
+    /// }
+    /// ```
+    pub fn values_mut(&mut self) -> impl Iterator<Item = &mut V> {
+        self.iter_mut().map(|(_, v)| v)
+    }
+}
+
+impl<'a, K, V, Q> ops::Index<&'a Q> for LinearMapView<K, V>
+where
+    K: Borrow<Q> + Eq,
+    Q: Eq + ?Sized,
+{
+    type Output = V;
+
+    fn index(&self, key: &Q) -> &V {
+        self.get(key).expect("no entry found for key")
+    }
+}
+
+impl<'a, K, V, Q> ops::IndexMut<&'a Q> for LinearMapView<K, V>
+where
+    K: Borrow<Q> + Eq,
+    Q: Eq + ?Sized,
+{
+    fn index_mut(&mut self, key: &Q) -> &mut V {
+        self.get_mut(key).expect("no entry found for key")
+    }
+}
+
+impl<K, V> fmt::Debug for LinearMapView<K, V>
+where
+    K: Eq + fmt::Debug,
+    V: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_map().entries(self.iter()).finish()
+    }
+}
+
 impl<K, V, const N: usize> FromIterator<(K, V)> for LinearMap<K, V, N>
 where
     K: Eq,
@@ -456,6 +855,18 @@ where
     }
 }
 
+impl<'a, K, V> IntoIterator for &'a LinearMapView<K, V>
+where
+    K: Eq,
+{
+    type Item = (&'a K, &'a V);
+    type IntoIter = Iter<'a, K, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Iter<'a, K, V> {
     iter: slice::Iter<'a, (K, V)>,
@@ -499,6 +910,26 @@ where
 }
 
 impl<K, V, const N: usize> Eq for LinearMap<K, V, N>
+where
+    K: Eq,
+    V: PartialEq,
+{
+}
+
+impl<K, V> PartialEq<LinearMapView<K, V>> for LinearMapView<K, V>
+where
+    K: Eq,
+    V: PartialEq,
+{
+    fn eq(&self, other: &LinearMapView<K, V>) -> bool {
+        self.len() == other.len()
+            && self
+                .iter()
+                .all(|(key, value)| other.get(key).map_or(false, |v| *value == *v))
+    }
+}
+
+impl<K, V> Eq for LinearMapView<K, V>
 where
     K: Eq,
     V: PartialEq,

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,8 +1,8 @@
 use core::hash::{BuildHasher, Hash};
 
 use crate::{
-    binary_heap::Kind as BinaryHeapKind, BinaryHeap, Deque, IndexMap, IndexSet, LinearMap, String,
-    Vec,
+    binary_heap::Kind as BinaryHeapKind,
+    BinaryHeap, Deque, IndexMap, IndexSet, String, Vec, {LinearMap, LinearMapView},
 };
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 
@@ -94,7 +94,7 @@ where
     }
 }
 
-impl<K, V, const N: usize> Serialize for LinearMap<K, V, N>
+impl<K, V> Serialize for LinearMapView<K, V>
 where
     K: Eq + Serialize,
     V: Serialize,
@@ -108,6 +108,19 @@ where
             map.serialize_entry(k, v)?;
         }
         map.end()
+    }
+}
+
+impl<K, V, const N: usize> Serialize for LinearMap<K, V, N>
+where
+    K: Eq + Serialize,
+    V: Serialize,
+{
+    fn serialize<SER>(&self, serializer: SER) -> Result<SER::Ok, SER::Error>
+    where
+        SER: Serializer,
+    {
+        self.as_view().serialize(serializer)
     }
 }
 


### PR DESCRIPTION
While implementing I realized that `&mut LinearMap` does not implement `IntoIter`. Should I add it ?  

I currently did not add it to `LinearMapView` either for symmetry, but that can lead to confusion. For example, the following doesn't compile:

```rust
use heapless::{LinearMap, LinearMapView};

let mut map: LinearMap<_, _, 8> = LinearMap::new();
let map_view: &mut LinearMapView<_, _> = &mut map;

for (key, val) in map_view {
    println!("key: {} val: {}", key, val);
}
```

The fix is to use instead 

```rust
for (key, val) in &*map_view {
```