### PR TITLE
BinaryHeap: add `BinaryHeapView`, similar to `VecView`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `VecView`, the `!Sized` version of `Vec`.
 - Added pool implementations for 64-bit architectures.
 - Added `IntoIterator` implementation for `LinearMap`
+- Added `BinaryHeapView`, the `!Sized` version of `BinaryHeap`.
 
 ### Changed
 

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -55,6 +55,13 @@ mod private {
     }
 }
 
+// Workaround https://github.com/rust-lang/rust/issues/119015. This is required so that the methods on `VecView` and `Vec` are properly documented.
+// cfg(doc) prevents `VecInner` being part of the public API.
+// doc(hidden) prevents the `pub use vec::VecInner` from being visible in the documentation.
+#[cfg(doc)]
+#[doc(hidden)]
+pub use private::BinaryHeapInner as _;
+
 impl private::Sealed for Max {}
 impl private::Sealed for Min {}
 

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -125,7 +125,7 @@ pub type BinaryHeap<T, K, const N: usize> = private::BinaryHeapInner<K, Vec<T, N
 /// use heapless::binary_heap::{BinaryHeap, BinaryHeapView, Max};
 ///
 /// let mut heap: BinaryHeap<_, Max, 8> = BinaryHeap::new();
-/// let mut heap_view: &mut BinaryHeapView<_, Max> = &mut heap;
+/// let heap_view: &mut BinaryHeapView<_, Max> = &mut heap;
 ///
 /// // We can use peek to look at the next item in the heap_view. In this case,
 /// // there's no items in there yet so we get None.
@@ -183,10 +183,44 @@ impl<T, K, const N: usize> BinaryHeap<T, K, N> {
         }
     }
 
+    /// Get a reference to the `BinaryHeap`, erasing the `N` const-generic
+    ///
+    /// ```
+    /// # use heapless::{BinaryHeap, BinaryHeapView, binary_heap::Max};
+    ///
+    /// let heap: BinaryHeap<u8, Max, 8> = BinaryHeap::new();
+    /// let heap_view: &BinaryHeapView<_, _> = heap.as_view();
+    /// ````
+    ///
+    /// It is often preferable to do the same through type coerction, since `BinaryHeap<T, K, N>` implements `Unsize<BinaryHeapView<T, K>>`:
+    ///
+    /// ```rust
+    /// # use heapless::{BinaryHeap, BinaryHeapView, binary_heap::Max};
+    ///
+    /// let heap: BinaryHeap<u8, Max, 8> = BinaryHeap::new();
+    /// let heap_view: &BinaryHeapView<_, _> = &heap;
+    /// ```
     pub fn as_view(&self) -> &BinaryHeapView<T, K> {
         self
     }
 
+    /// Get a mutable reference to the `BinaryHeap`, erasing the `N` const-generic
+    ///
+    /// ```
+    /// # use heapless::{BinaryHeap, BinaryHeapView, binary_heap::Max};
+    ///
+    /// let mut heap: BinaryHeap<u8, Max, 8> = BinaryHeap::new();
+    /// let heap_view: &mut BinaryHeapView<_, _> = heap.as_mut_view();
+    /// ````
+    ///
+    /// It is often preferable to do the same through type coerction, since `BinaryHeap<T, K, N>` implements `Unsize<BinaryHeapView<T, K>>`:
+    ///
+    /// ```rust
+    /// # use heapless::{BinaryHeap, BinaryHeapView, binary_heap::Max};
+    ///
+    /// let mut heap: BinaryHeap<u8, Max, 8> = BinaryHeap::new();
+    /// let heap_view: &mut BinaryHeapView<_, _> = &mut heap;
+    /// ```
     pub fn as_mut_view(&mut self) -> &mut BinaryHeapView<T, K> {
         self
     }

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -49,6 +49,7 @@ mod private {
 
     pub trait Sealed {}
 
+    /// <div class="warn">This is private API and should not be used</div>
     pub struct BinaryHeapInner<K, B: ?Sized> {
         pub(crate) _kind: PhantomData<K>,
         pub(crate) data: B,

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -17,7 +17,7 @@ use core::{
     ptr, slice,
 };
 
-use crate::vec::Vec;
+use crate::{vec::Vec, VecView};
 
 /// Min-heap
 pub enum Min {}
@@ -45,7 +45,14 @@ impl Kind for Max {
 
 /// Sealed traits
 mod private {
+    use core::marker::PhantomData;
+
     pub trait Sealed {}
+
+    pub struct BinaryHeapInner<K, B: ?Sized> {
+        pub(crate) _kind: PhantomData<K>,
+        pub(crate) data: B,
+    }
 }
 
 impl private::Sealed for Max {}
@@ -97,10 +104,56 @@ impl private::Sealed for Min {}
 /// // The heap should now be empty.
 /// assert!(heap.is_empty())
 /// ```
-pub struct BinaryHeap<T, K, const N: usize> {
-    pub(crate) _kind: PhantomData<K>,
-    pub(crate) data: Vec<T, N>,
-}
+pub type BinaryHeap<T, K, const N: usize> = private::BinaryHeapInner<K, Vec<T, N>>;
+
+/// A priority queue implemented with a binary heap.
+///
+/// This can be either a min-heap or a max-heap.
+///
+/// It is a logic error for an item to be modified in such a way that the item's ordering relative
+/// to any other item, as determined by the `Ord` trait, changes while it is in the heap. This is
+/// normally only possible through `Cell`, `RefCell`, global state, I/O, or unsafe code.
+///
+/// ```
+/// use heapless::binary_heap::{BinaryHeapView, BinaryHeap, Max};
+///
+/// let mut heap: BinaryHeap<_, Max, 8> = BinaryHeap::new();
+/// let mut heap_view: &mut BinaryHeapView<_, Max> = &mut heap;
+///
+/// // We can use peek to look at the next item in the heap_view. In this case,
+/// // there's no items in there yet so we get None.
+/// assert_eq!(heap_view.peek(), None);
+///
+/// // Let's add some scores...
+/// heap_view.push(1).unwrap();
+/// heap_view.push(5).unwrap();
+/// heap_view.push(2).unwrap();
+///
+/// // Now peek shows the most important item in the heap.
+/// assert_eq!(heap_view.peek(), Some(&5));
+///
+/// // We can check the length of a heap.
+/// assert_eq!(heap_view.len(), 3);
+///
+/// // We can iterate over the items in the heap, although they are returned in
+/// // a random order.
+/// for x in &*heap_view {
+///     println!("{}", x);
+/// }
+///
+/// // If we instead pop these scores, they should come back in order.
+/// assert_eq!(heap_view.pop(), Some(5));
+/// assert_eq!(heap_view.pop(), Some(2));
+/// assert_eq!(heap_view.pop(), Some(1));
+/// assert_eq!(heap_view.pop(), None);
+///
+/// // We can clear the heap of any remaining items.
+/// heap_view.clear();
+///
+/// // The heap_view should now be empty.
+/// assert!(heap_view.is_empty())
+/// ```
+pub type BinaryHeapView<T, K> = private::BinaryHeapInner<K, VecView<T>>;
 
 impl<T, K, const N: usize> BinaryHeap<T, K, N> {
     /* Constructors */
@@ -121,6 +174,14 @@ impl<T, K, const N: usize> BinaryHeap<T, K, N> {
             _kind: PhantomData,
             data: Vec::new(),
         }
+    }
+
+    pub fn as_view(&self) -> &BinaryHeapView<T, K> {
+        self
+    }
+
+    pub fn as_mut_view(&self) -> &BinaryHeapView<T, K> {
+        self
     }
 }
 
@@ -379,6 +440,256 @@ where
     }
 }
 
+impl<T, K> BinaryHeapView<T, K>
+where
+    T: Ord,
+    K: Kind,
+{
+    /* Public API */
+    /// Returns the capacity of the binary heap.
+    pub fn capacity(&self) -> usize {
+        self.data.capacity()
+    }
+
+    /// Drops all items from the binary heap.
+    ///
+    /// ```
+    /// use heapless::binary_heap::{BinaryHeap, Max};
+    ///
+    /// let mut heap: BinaryHeap<_, Max, 8> = BinaryHeap::new();
+    /// heap.push(1).unwrap();
+    /// heap.push(3).unwrap();
+    ///
+    /// assert!(!heap.is_empty());
+    ///
+    /// heap.clear();
+    ///
+    /// assert!(heap.is_empty());
+    /// ```
+    pub fn clear(&mut self) {
+        self.data.clear()
+    }
+
+    /// Returns the length of the binary heap.
+    ///
+    /// ```
+    /// use heapless::binary_heap::{BinaryHeap, Max};
+    ///
+    /// let mut heap: BinaryHeap<_, Max, 8> = BinaryHeap::new();
+    /// heap.push(1).unwrap();
+    /// heap.push(3).unwrap();
+    ///
+    /// assert_eq!(heap.len(), 2);
+    /// ```
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Checks if the binary heap is empty.
+    ///
+    /// ```
+    /// use heapless::binary_heap::{BinaryHeap, Max};
+    ///
+    /// let mut heap: BinaryHeap<_, Max, 8> = BinaryHeap::new();
+    ///
+    /// assert!(heap.is_empty());
+    ///
+    /// heap.push(3).unwrap();
+    /// heap.push(5).unwrap();
+    /// heap.push(1).unwrap();
+    ///
+    /// assert!(!heap.is_empty());
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns an iterator visiting all values in the underlying vector, in arbitrary order.
+    ///
+    /// ```
+    /// use heapless::binary_heap::{BinaryHeap, Max};
+    ///
+    /// let mut heap: BinaryHeap<_, Max, 8> = BinaryHeap::new();
+    /// heap.push(1).unwrap();
+    /// heap.push(2).unwrap();
+    /// heap.push(3).unwrap();
+    /// heap.push(4).unwrap();
+    ///
+    /// // Print 1, 2, 3, 4 in arbitrary order
+    /// for x in heap.iter() {
+    ///     println!("{}", x);
+    /// }
+    /// ```
+    pub fn iter(&self) -> slice::Iter<'_, T> {
+        self.data.as_slice().iter()
+    }
+
+    /// Returns a mutable iterator visiting all values in the underlying vector, in arbitrary order.
+    ///
+    /// **WARNING** Mutating the items in the binary heap can leave the heap in an inconsistent
+    /// state.
+    pub fn iter_mut(&mut self) -> slice::IterMut<'_, T> {
+        self.data.as_mut_slice().iter_mut()
+    }
+
+    /// Returns the *top* (greatest if max-heap, smallest if min-heap) item in the binary heap, or
+    /// None if it is empty.
+    ///
+    /// ```
+    /// use heapless::binary_heap::{BinaryHeap, Max};
+    ///
+    /// let mut heap: BinaryHeap<_, Max, 8> = BinaryHeap::new();
+    /// assert_eq!(heap.peek(), None);
+    ///
+    /// heap.push(1).unwrap();
+    /// heap.push(5).unwrap();
+    /// heap.push(2).unwrap();
+    /// assert_eq!(heap.peek(), Some(&5));
+    /// ```
+    pub fn peek(&self) -> Option<&T> {
+        self.data.as_slice().first()
+    }
+
+    /// Returns a mutable reference to the greatest item in the binary heap, or
+    /// `None` if it is empty.
+    ///
+    /// Note: If the `PeekMut` value is leaked, the heap may be in an
+    /// inconsistent state.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use heapless::binary_heap::{BinaryHeap, Max};
+    ///
+    /// let mut heap: BinaryHeap<_, Max, 8> = BinaryHeap::new();
+    /// assert!(heap.peek_mut().is_none());
+    ///
+    /// heap.push(1);
+    /// heap.push(5);
+    /// heap.push(2);
+    /// {
+    ///     let mut val = heap.peek_mut().unwrap();
+    ///     *val = 0;
+    /// }
+    ///
+    /// assert_eq!(heap.peek(), Some(&2));
+    /// ```
+    pub fn peek_mut(&mut self) -> Option<PeekMutView<'_, T, K>> {
+        if self.is_empty() {
+            None
+        } else {
+            Some(PeekMutView {
+                heap: self,
+                sift: true,
+            })
+        }
+    }
+
+    /// Removes the *top* (greatest if max-heap, smallest if min-heap) item from the binary heap and
+    /// returns it, or None if it is empty.
+    ///
+    /// ```
+    /// use heapless::binary_heap::{BinaryHeap, Max};
+    ///
+    /// let mut heap: BinaryHeap<_, Max, 8> = BinaryHeap::new();
+    /// heap.push(1).unwrap();
+    /// heap.push(3).unwrap();
+    ///
+    /// assert_eq!(heap.pop(), Some(3));
+    /// assert_eq!(heap.pop(), Some(1));
+    /// assert_eq!(heap.pop(), None);
+    /// ```
+    pub fn pop(&mut self) -> Option<T> {
+        if self.is_empty() {
+            None
+        } else {
+            Some(unsafe { self.pop_unchecked() })
+        }
+    }
+
+    /// Removes the *top* (greatest if max-heap, smallest if min-heap) item from the binary heap and
+    /// returns it, without checking if the binary heap is empty.
+    #[allow(clippy::missing_safety_doc)] // TODO
+    pub unsafe fn pop_unchecked(&mut self) -> T {
+        let mut item = self.data.pop_unchecked();
+
+        if !self.is_empty() {
+            mem::swap(&mut item, self.data.as_mut_slice().get_unchecked_mut(0));
+            self.sift_down_to_bottom(0);
+        }
+        item
+    }
+
+    /// Pushes an item onto the binary heap.
+    ///
+    /// ```
+    /// use heapless::binary_heap::{BinaryHeap, Max};
+    ///
+    /// let mut heap: BinaryHeap<_, Max, 8> = BinaryHeap::new();
+    /// heap.push(3).unwrap();
+    /// heap.push(5).unwrap();
+    /// heap.push(1).unwrap();
+    ///
+    /// assert_eq!(heap.len(), 3);
+    /// assert_eq!(heap.peek(), Some(&5));
+    /// ```
+    pub fn push(&mut self, item: T) -> Result<(), T> {
+        if self.data.is_full() {
+            return Err(item);
+        }
+
+        unsafe { self.push_unchecked(item) }
+        Ok(())
+    }
+
+    /// Pushes an item onto the binary heap without first checking if it's full.
+    #[allow(clippy::missing_safety_doc)] // TODO
+    pub unsafe fn push_unchecked(&mut self, item: T) {
+        let old_len = self.len();
+        self.data.push_unchecked(item);
+        self.sift_up(0, old_len);
+    }
+
+    /* Private API */
+    fn sift_down_to_bottom(&mut self, mut pos: usize) {
+        let end = self.len();
+        let start = pos;
+        unsafe {
+            let mut hole = Hole::new(self.data.as_mut_slice(), pos);
+            let mut child = 2 * pos + 1;
+            while child < end {
+                let right = child + 1;
+                // compare with the greater of the two children
+                if right < end && hole.get(child).cmp(hole.get(right)) != K::ordering() {
+                    child = right;
+                }
+                hole.move_to(child);
+                child = 2 * hole.pos() + 1;
+            }
+            pos = hole.pos;
+        }
+        self.sift_up(start, pos);
+    }
+
+    fn sift_up(&mut self, start: usize, pos: usize) -> usize {
+        unsafe {
+            // Take out the value at `pos` and create a hole.
+            let mut hole = Hole::new(self.data.as_mut_slice(), pos);
+
+            while hole.pos() > start {
+                let parent = (hole.pos() - 1) / 2;
+                if hole.element().cmp(hole.get(parent)) != K::ordering() {
+                    break;
+                }
+                hole.move_to(parent);
+            }
+            hole.pos()
+        }
+    }
+}
+
 /// Hole represents a hole in a slice i.e. an index without valid value
 /// (because it was moved from or duplicated).
 /// In drop, `Hole` will restore the slice by filling the hole
@@ -505,6 +816,70 @@ where
     }
 }
 
+/// Structure wrapping a mutable reference to the greatest item on a
+/// `BinaryHeap`.
+///
+/// This `struct` is created by [`BinaryHeap::peek_mut`].
+/// See its documentation for more.
+pub struct PeekMutView<'a, T, K>
+where
+    T: Ord,
+    K: Kind,
+{
+    heap: &'a mut BinaryHeapView<T, K>,
+    sift: bool,
+}
+
+impl<T, K> Drop for PeekMutView<'_, T, K>
+where
+    T: Ord,
+    K: Kind,
+{
+    fn drop(&mut self) {
+        if self.sift {
+            self.heap.sift_down_to_bottom(0);
+        }
+    }
+}
+
+impl<T, K> Deref for PeekMutView<'_, T, K>
+where
+    T: Ord,
+    K: Kind,
+{
+    type Target = T;
+    fn deref(&self) -> &T {
+        debug_assert!(!self.heap.is_empty());
+        // SAFE: PeekMut is only instantiated for non-empty heaps
+        unsafe { self.heap.data.as_slice().get_unchecked(0) }
+    }
+}
+
+impl<T, K> DerefMut for PeekMutView<'_, T, K>
+where
+    T: Ord,
+    K: Kind,
+{
+    fn deref_mut(&mut self) -> &mut T {
+        debug_assert!(!self.heap.is_empty());
+        // SAFE: PeekMut is only instantiated for non-empty heaps
+        unsafe { self.heap.data.as_mut_slice().get_unchecked_mut(0) }
+    }
+}
+
+impl<'a, T, K> PeekMutView<'a, T, K>
+where
+    T: Ord,
+    K: Kind,
+{
+    /// Removes the peeked value from the heap and returns it.
+    pub fn pop(mut this: PeekMutView<'a, T, K>) -> T {
+        let value = this.heap.pop().unwrap();
+        this.sift = false;
+        value
+    }
+}
+
 impl<'a, T> Drop for Hole<'a, T> {
     #[inline]
     fn drop(&mut self) {
@@ -545,11 +920,34 @@ where
     T: Ord + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_view().fmt(f)
+    }
+}
+
+impl<T, K> fmt::Debug for BinaryHeapView<T, K>
+where
+    K: Kind,
+    T: Ord + fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.iter()).finish()
     }
 }
 
 impl<'a, T, K, const N: usize> IntoIterator for &'a BinaryHeap<T, K, N>
+where
+    K: Kind,
+    T: Ord,
+{
+    type Item = &'a T;
+    type IntoIter = slice::Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.as_view().into_iter()
+    }
+}
+
+impl<'a, T, K> IntoIterator for &'a BinaryHeapView<T, K>
 where
     K: Kind,
     T: Ord,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@
     feature(integer_atomics)
 )]
 
-pub use binary_heap::BinaryHeap;
+pub use binary_heap::{BinaryHeap, BinaryHeapView};
 pub use deque::Deque;
 pub use histbuf::{HistoryBuffer, OldestOrdered};
 pub use indexmap::{

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,14 +1,27 @@
 use core::hash::{BuildHasher, Hash};
 
 use crate::{
-    binary_heap::Kind as BinaryHeapKind, BinaryHeap, Deque, IndexMap, IndexSet, LinearMap, String,
-    Vec,
+    binary_heap::Kind as BinaryHeapKind, BinaryHeap, BinaryHeapView, Deque, IndexMap, IndexSet,
+    LinearMap, String, Vec,
 };
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 
 // Sequential containers
 
 impl<T, KIND, const N: usize> Serialize for BinaryHeap<T, KIND, N>
+where
+    T: Ord + Serialize,
+    KIND: BinaryHeapKind,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.as_view().serialize(serializer)
+    }
+}
+
+impl<T, KIND> Serialize for BinaryHeapView<T, KIND>
 where
     T: Ord + Serialize,
     KIND: BinaryHeapKind,


### PR DESCRIPTION
I left the `PeekMut` implementation as_is and duplicated it into `PeekMutView`, since it would be a breaking change to remove the `N` const generic on it. But I think it should be removed with the next breaking change release.