### PR TITLE
`spsc::Queue`: add `spsc::QueueView`, similar to `VecView`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `VecView`, the `!Sized` version of `Vec`.
 - Added pool implementations for 64-bit architectures.
 - Added `IntoIterator` implementation for `LinearMap`
+- Added `spsc::QueueView`, the `!Sized` version of `spsc::Queue`.
 
 ### Changed
 


### PR DESCRIPTION
Similarly to https://github.com/rust-embedded/heapless/pull/480,  there are structs which keep the `const` generic `N` for backwards compatibility (`Iter`, `IterMut`, `Producer`, `Consumer`).