### PR TITLE
vec: remove code duplication due to VecView.

### DIFF
--- a/src/defmt.rs
+++ b/src/defmt.rs
@@ -1,9 +1,9 @@
 //! Defmt implementations for heapless types
 
-use crate::Vec;
+use crate::{storage::Storage, vec::VecInner};
 use defmt::Formatter;
 
-impl<T, const N: usize> defmt::Format for Vec<T, N>
+impl<T, S: Storage> defmt::Format for VecInner<T, S>
 where
     T: defmt::Format,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,13 +96,6 @@ pub use indexmap::{
 pub use indexset::{FnvIndexSet, IndexSet, Iter as IndexSetIter};
 pub use linear_map::LinearMap;
 pub use string::String;
-
-// Workaround https://github.com/rust-lang/rust/issues/119015. This is required so that the methods on `VecView` and `Vec` are properly documented.
-// cfg(doc) prevents `VecInner` being part of the public API.
-// doc(hidden) prevents the `pub use vec::VecInner` from being visible in the documentation.
-#[cfg(doc)]
-#[doc(hidden)]
-pub use vec::VecInner as _;
 pub use vec::{Vec, VecView};
 
 #[macro_use]
@@ -114,8 +107,9 @@ mod histbuf;
 mod indexmap;
 mod indexset;
 mod linear_map;
+pub mod storage;
 pub mod string;
-mod vec;
+pub mod vec;
 
 #[cfg(feature = "serde")]
 mod de;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,8 +1,8 @@
 use core::hash::{BuildHasher, Hash};
 
 use crate::{
-    binary_heap::Kind as BinaryHeapKind, BinaryHeap, Deque, IndexMap, IndexSet, LinearMap, String,
-    Vec,
+    binary_heap::Kind as BinaryHeapKind, storage::Storage, vec::VecInner, BinaryHeap, Deque,
+    IndexMap, IndexSet, LinearMap, String,
 };
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 
@@ -42,7 +42,7 @@ where
     }
 }
 
-impl<T, const N: usize> Serialize for Vec<T, N>
+impl<T, St: Storage> Serialize for VecInner<T, St>
 where
     T: Serialize,
 {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -13,7 +13,15 @@ pub(crate) trait SealedStorage {
 /// - [`OwnedStorage`]: stores the data in an array `[T; N]` whose size is known at compile time.
 /// - [`ViewStorage`]: stores the data in an unsized `[T]`.
 ///
-/// This allows containers to be generic over either sized or unsized storage.
+/// This allows containers to be generic over either sized or unsized storage. For example,
+/// the [`vec`](crate::vec) module contains a [`VecInner`](crate::vec::VecInner) struct
+/// that's generic on [`Storage`], and two type aliases for convenience:
+///
+/// - [`Vec<T, N>`](crate::vec::Vec) = `VecInner<T, OwnedStorage<N>>`
+/// - [`VecView<T>`](crate::vec::VecView) = `VecInner<T, ViewStorage>`
+///
+/// `Vec` can be unsized into `VecView`, either by unsizing coercions such as `&mut Vec -> &mut VecView` or
+/// `Box<Vec> -> Box<VecView>`, or explicitly with [`.as_view()`](crate::vec::Vec::as_view) or [`.as_mut_view()`](crate::vec::Vec::as_mut_view).
 ///
 /// This trait is sealed, so you cannot implement it for your own types. You can only use
 /// the implementations provided by this crate.

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,35 @@
+//! `Storage` trait defining how data is stored in a container.
+
+use core::borrow::{Borrow, BorrowMut};
+
+pub(crate) trait SealedStorage {
+    type Buffer<T>: ?Sized + Borrow<[T]> + BorrowMut<[T]>;
+}
+
+/// Trait defining how data for a container is stored.
+///
+/// There's two implementations available:
+///
+/// - [`OwnedStorage`]: stores the data in an array `[T; N]` whose size is known at compile time.
+/// - [`ViewStorage`]: stores the data in an unsized `[T]`.
+///
+/// This allows containers to be generic over either sized or unsized storage.
+///
+/// This trait is sealed, so you cannot implement it for your own types. You can only use
+/// the implementations provided by this crate.
+#[allow(private_bounds)]
+pub trait Storage: SealedStorage {}
+
+/// Implementation of [`Storage`] that stores the data in an array `[T; N]` whose size is known at compile time.
+pub enum OwnedStorage<const N: usize> {}
+impl<const N: usize> Storage for OwnedStorage<N> {}
+impl<const N: usize> SealedStorage for OwnedStorage<N> {
+    type Buffer<T> = [T; N];
+}
+
+/// Implementation of [`Storage`] that stores the data in an unsized `[T]`.
+pub enum ViewStorage {}
+impl Storage for ViewStorage {}
+impl SealedStorage for ViewStorage {
+    type Buffer<T> = [T];
+}

--- a/src/ufmt.rs
+++ b/src/ufmt.rs
@@ -1,4 +1,4 @@
-use crate::{string::String, vec::Vec};
+use crate::{storage::Storage, string::String, vec::VecInner};
 use ufmt_write::uWrite;
 
 impl<const N: usize> uWrite for String<N> {
@@ -8,7 +8,7 @@ impl<const N: usize> uWrite for String<N> {
     }
 }
 
-impl<const N: usize> uWrite for Vec<u8, N> {
+impl<S: Storage> uWrite for VecInner<u8, S> {
     type Error = ();
     fn write_str(&mut self, s: &str) -> Result<(), Self::Error> {
         self.extend_from_slice(s.as_bytes())
@@ -17,7 +17,7 @@ impl<const N: usize> uWrite for Vec<u8, N> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::{String, Vec};
 
     use ufmt::{derive::uDebug, uwrite};
 

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1,43 +1,22 @@
+//! A fixed capacity [`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html).
+
 use core::{
+    borrow::{Borrow, BorrowMut},
     cmp::Ordering,
-    fmt, hash, mem,
-    mem::{ManuallyDrop, MaybeUninit},
+    fmt, hash,
+    mem::{self, ManuallyDrop, MaybeUninit},
     ops, ptr, slice,
 };
 
-pub trait VecBuffer {
-    type T;
+use crate::storage::{OwnedStorage, Storage, ViewStorage};
 
-    fn as_vecview(vec: &VecInner<Self>) -> &VecView<Self::T>;
-    fn as_mut_vecview(vec: &mut VecInner<Self>) -> &mut VecView<Self::T>;
-}
-
-impl<T, const N: usize> VecBuffer for [MaybeUninit<T>; N] {
-    type T = T;
-
-    fn as_vecview(vec: &VecInner<Self>) -> &VecView<Self::T> {
-        vec
-    }
-    fn as_mut_vecview(vec: &mut VecInner<Self>) -> &mut VecView<Self::T> {
-        vec
-    }
-}
-
-impl<T> VecBuffer for [MaybeUninit<T>] {
-    type T = T;
-
-    fn as_vecview(vec: &VecInner<Self>) -> &VecView<Self::T> {
-        vec
-    }
-    fn as_mut_vecview(vec: &mut VecInner<Self>) -> &mut VecView<Self::T> {
-        vec
-    }
-}
-
-/// <div class="warn">This is private API and should not be used</div>
-pub struct VecInner<B: ?Sized + VecBuffer> {
+/// Base struct for [`Vec`] and [`VecView`], generic over the [`Storage`].
+///
+/// In most cases you should use [`Vec`] or [`VecView`] directly. Only use this
+/// struct if you want to write code that's generic over both.
+pub struct VecInner<T, S: Storage> {
     len: usize,
-    buffer: B,
+    buffer: S::Buffer<MaybeUninit<T>>,
 }
 
 /// A fixed capacity [`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html).
@@ -77,7 +56,7 @@ pub struct VecInner<B: ?Sized + VecBuffer> {
 /// let vec: Vec<u8, 10> = Vec::from_slice(&[1, 2, 3, 4]).unwrap();
 /// let view: &VecView<_> = &vec;
 /// ```
-pub type Vec<T, const N: usize> = VecInner<[MaybeUninit<T>; N]>;
+pub type Vec<T, const N: usize> = VecInner<T, OwnedStorage<N>>;
 
 /// A [`Vec`] with dynamic capacity
 ///
@@ -100,17 +79,184 @@ pub type Vec<T, const N: usize> = VecInner<[MaybeUninit<T>; N]>;
 /// mut_view.push(5);
 /// assert_eq!(vec, [1, 2, 3, 4, 5]);
 /// ```
-pub type VecView<T> = VecInner<[MaybeUninit<T>]>;
+pub type VecView<T> = VecInner<T, ViewStorage>;
 
-impl<T> VecView<T> {
+impl<T, const N: usize> Vec<T, N> {
+    const ELEM: MaybeUninit<T> = MaybeUninit::uninit();
+    const INIT: [MaybeUninit<T>; N] = [Self::ELEM; N]; // important for optimization of `new`
+
+    /// Constructs a new, empty vector with a fixed capacity of `N`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use heapless::Vec;
+    ///
+    /// // allocate the vector on the stack
+    /// let mut x: Vec<u8, 16> = Vec::new();
+    ///
+    /// // allocate the vector in a static variable
+    /// static mut X: Vec<u8, 16> = Vec::new();
+    /// ```
+    pub const fn new() -> Self {
+        Self {
+            len: 0,
+            buffer: Self::INIT,
+        }
+    }
+
+    /// Constructs a new vector with a fixed capacity of `N` and fills it
+    /// with the provided slice.
+    ///
+    /// This is equivalent to the following code:
+    ///
+    /// ```
+    /// use heapless::Vec;
+    ///
+    /// let mut v: Vec<u8, 16> = Vec::new();
+    /// v.extend_from_slice(&[1, 2, 3]).unwrap();
+    /// ```
+    #[allow(clippy::result_unit_err)]
+    pub fn from_slice(other: &[T]) -> Result<Self, ()>
+    where
+        T: Clone,
+    {
+        let mut v = Vec::new();
+        v.extend_from_slice(other)?;
+        Ok(v)
+    }
+
+    /// Constructs a new vector with a fixed capacity of `N`, initializing
+    /// it with the provided array.
+    ///
+    /// The length of the provided array, `M` may be equal to _or_ less than
+    /// the capacity of the vector, `N`.
+    ///
+    /// If the length of the provided array is greater than the capacity of the
+    /// vector a compile-time error will be produced.
+    pub fn from_array<const M: usize>(src: [T; M]) -> Self {
+        // Const assert M >= 0
+        crate::sealed::greater_than_eq_0::<M>();
+        // Const assert N >= M
+        crate::sealed::greater_than_eq::<N, M>();
+
+        // We've got to copy `src`, but we're functionally moving it. Don't run
+        // any Drop code for T.
+        let src = ManuallyDrop::new(src);
+
+        if N == M {
+            Self {
+                len: N,
+                // NOTE(unsafe) ManuallyDrop<[T; M]> and [MaybeUninit<T>; N]
+                // have the same layout when N == M.
+                buffer: unsafe { mem::transmute_copy(&src) },
+            }
+        } else {
+            let mut v = Vec::<T, N>::new();
+
+            for (src_elem, dst_elem) in src.iter().zip(v.buffer.iter_mut()) {
+                // NOTE(unsafe) src element is not going to drop as src itself
+                // is wrapped in a ManuallyDrop.
+                dst_elem.write(unsafe { ptr::read(src_elem) });
+            }
+
+            v.len = M;
+            v
+        }
+    }
+
+    /// Returns the contents of the vector as an array of length `M` if the length
+    /// of the vector is exactly `M`, otherwise returns `Err(self)`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use heapless::Vec;
+    /// let buffer: Vec<u8, 42> = Vec::from_slice(&[1, 2, 3, 5, 8]).unwrap();
+    /// let array: [u8; 5] = buffer.into_array().unwrap();
+    /// assert_eq!(array, [1, 2, 3, 5, 8]);
+    /// ```
+    pub fn into_array<const M: usize>(self) -> Result<[T; M], Self> {
+        if self.len() == M {
+            // This is how the unstable `MaybeUninit::array_assume_init` method does it
+            let array = unsafe { (&self.buffer as *const _ as *const [T; M]).read() };
+
+            // We don't want `self`'s destructor to be called because that would drop all the
+            // items in the array
+            core::mem::forget(self);
+
+            Ok(array)
+        } else {
+            Err(self)
+        }
+    }
+
+    /// Clones a vec into a new vec
+    pub(crate) fn clone(&self) -> Self
+    where
+        T: Clone,
+    {
+        let mut new = Self::new();
+        // avoid `extend_from_slice` as that introduces a runtime check/panicking branch
+        for elem in self {
+            unsafe {
+                new.push_unchecked(elem.clone());
+            }
+        }
+        new
+    }
+
+    /// Get a reference to the `Vec`, erasing the `N` const-generic.
+    ///
+    ///
+    /// ```rust
+    /// # use heapless::{Vec, VecView};
+    /// let vec: Vec<u8, 10> = Vec::from_slice(&[1, 2, 3, 4]).unwrap();
+    /// let view: &VecView<u8> = vec.as_view();
+    /// ```
+    ///
+    /// It is often preferable to do the same through type coerction, since `Vec<T, N>` implements `Unsize<VecView<T>>`:
+    ///
+    /// ```rust
+    /// # use heapless::{Vec, VecView};
+    /// let vec: Vec<u8, 10> = Vec::from_slice(&[1, 2, 3, 4]).unwrap();
+    /// let view: &VecView<u8> = &vec;
+    /// ```
+    #[inline]
+    pub const fn as_view(&self) -> &VecView<T> {
+        self
+    }
+
+    /// Get a mutable reference to the `Vec`, erasing the `N` const-generic.
+    ///
+    /// ```rust
+    /// # use heapless::{Vec, VecView};
+    /// let mut vec: Vec<u8, 10> = Vec::from_slice(&[1, 2, 3, 4]).unwrap();
+    /// let view: &mut VecView<u8> = vec.as_mut_view();
+    /// ```
+    ///
+    /// It is often preferable to do the same through type coerction, since `Vec<T, N>` implements `Unsize<VecView<T>>`:
+    ///
+    /// ```rust
+    /// # use heapless::{Vec, VecView};
+    /// let mut vec: Vec<u8, 10> = Vec::from_slice(&[1, 2, 3, 4]).unwrap();
+    /// let view: &mut VecView<u8> = &mut vec;
+    /// ```
+    #[inline]
+    pub fn as_mut_view(&mut self) -> &mut VecView<T> {
+        self
+    }
+}
+
+impl<T, S: Storage> VecInner<T, S> {
     /// Returns a raw pointer to the vector’s buffer.
     pub fn as_ptr(&self) -> *const T {
-        self.buffer.as_ptr() as *const T
+        self.buffer.borrow().as_ptr() as *const T
     }
 
     /// Returns a raw pointer to the vector’s buffer, which may be mutated through.
     pub fn as_mut_ptr(&mut self) -> *mut T {
-        self.buffer.as_mut_ptr() as *mut T
+        self.buffer.borrow_mut().as_mut_ptr() as *mut T
     }
 
     /// Extracts a slice containing the entire vector.
@@ -120,15 +266,14 @@ impl<T> VecView<T> {
     /// # Examples
     ///
     /// ```
-    /// use heapless::{Vec, VecView};
-    ///
-    /// let buffer: &VecView<u8> = &Vec::<u8, 5>::from_slice(&[1, 2, 3, 5, 8]).unwrap();
+    /// use heapless::Vec;
+    /// let buffer: Vec<u8, 5> = Vec::from_slice(&[1, 2, 3, 5, 8]).unwrap();
     /// assert_eq!(buffer.as_slice(), &[1, 2, 3, 5, 8]);
     /// ```
     pub fn as_slice(&self) -> &[T] {
         // NOTE(unsafe) avoid bound checks in the slicing operation
         // &buffer[..self.len]
-        unsafe { slice::from_raw_parts(self.buffer.as_ptr() as *const T, self.len) }
+        unsafe { slice::from_raw_parts(self.buffer.borrow().as_ptr() as *const T, self.len) }
     }
 
     /// Extracts a mutable slice containing the entire vector.
@@ -138,8 +283,8 @@ impl<T> VecView<T> {
     /// # Examples
     ///
     /// ```
-    /// use heapless::{Vec, VecView};
-    /// let mut buffer: &mut VecView<u8> = &mut Vec::<u8, 5>::from_slice(&[1, 2, 3, 5, 8]).unwrap();
+    /// use heapless::Vec;
+    /// let mut buffer: Vec<u8, 5> = Vec::from_slice(&[1, 2, 3, 5, 8]).unwrap();
     /// let buffer_slice = buffer.as_mut_slice();
     /// buffer_slice[0] = 9;
     /// assert_eq!(buffer.as_slice(), &[9, 2, 3, 5, 8]);
@@ -147,12 +292,14 @@ impl<T> VecView<T> {
     pub fn as_mut_slice(&mut self) -> &mut [T] {
         // NOTE(unsafe) avoid bound checks in the slicing operation
         // &mut buffer[..self.len]
-        unsafe { slice::from_raw_parts_mut(self.buffer.as_mut_ptr() as *mut T, self.len) }
+        unsafe {
+            slice::from_raw_parts_mut(self.buffer.borrow_mut().as_mut_ptr() as *mut T, self.len)
+        }
     }
 
     /// Returns the maximum number of elements the vector can hold.
-    pub const fn capacity(&self) -> usize {
-        self.buffer.len()
+    pub fn capacity(&self) -> usize {
+        self.buffer.borrow().len()
     }
 
     /// Clears the vector, removing all values.
@@ -182,9 +329,9 @@ impl<T> VecView<T> {
     /// # Examples
     ///
     /// ```
-    /// use heapless::{Vec, VecView};
+    /// use heapless::Vec;
     ///
-    /// let vec: &mut VecView<u8> = &mut Vec::<u8, 8>::new();
+    /// let mut vec = Vec::<u8, 8>::new();
     /// vec.push(1).unwrap();
     /// vec.extend_from_slice(&[2, 3, 4]).unwrap();
     /// assert_eq!(*vec, [1, 2, 3, 4]);
@@ -237,7 +384,11 @@ impl<T> VecView<T> {
         debug_assert!(!self.is_empty());
 
         self.len -= 1;
-        self.buffer.get_unchecked_mut(self.len).as_ptr().read()
+        self.buffer
+            .borrow_mut()
+            .get_unchecked_mut(self.len)
+            .as_ptr()
+            .read()
     }
 
     /// Appends an `item` to the back of the collection
@@ -250,7 +401,7 @@ impl<T> VecView<T> {
         // use `ptr::write` to avoid running `T`'s destructor on the uninitialized memory
         debug_assert!(!self.is_full());
 
-        *self.buffer.get_unchecked_mut(self.len) = MaybeUninit::new(item);
+        *self.buffer.borrow_mut().get_unchecked_mut(self.len) = MaybeUninit::new(item);
 
         self.len += 1;
     }
@@ -318,840 +469,6 @@ impl<T> VecView<T> {
         T: Clone + Default,
     {
         self.resize(new_len, T::default())
-    }
-
-    /// Forces the length of the vector to `new_len`.
-    ///
-    /// This is a low-level operation that maintains none of the normal
-    /// invariants of the type. Normally changing the length of a vector
-    /// is done using one of the safe operations instead, such as
-    /// [`truncate`], [`resize`], [`extend`], or [`clear`].
-    ///
-    /// [`truncate`]: Self::truncate
-    /// [`resize`]: Self::resize
-    /// [`extend`]: core::iter::Extend
-    /// [`clear`]: Self::clear
-    ///
-    /// # Safety
-    ///
-    /// - `new_len` must be less than or equal to [`capacity()`].
-    /// - The elements at `old_len..new_len` must be initialized.
-    ///
-    /// [`capacity()`]: Self::capacity
-    ///
-    /// # Examples
-    ///
-    /// This method can be useful for situations in which the vector
-    /// is serving as a buffer for other code, particularly over FFI:
-    ///
-    /// ```no_run
-    /// # #![allow(dead_code)]
-    /// use heapless::{Vec, VecView};
-    ///
-    /// # // This is just a minimal skeleton for the doc example;
-    /// # // don't use this as a starting point for a real library.
-    /// # pub struct StreamWrapper { strm: *mut core::ffi::c_void }
-    /// # const Z_OK: i32 = 0;
-    /// # extern "C" {
-    /// #     fn deflateGetDictionary(
-    /// #         strm: *mut core::ffi::c_void,
-    /// #         dictionary: *mut u8,
-    /// #         dictLength: *mut usize,
-    /// #     ) -> i32;
-    /// # }
-    /// # impl StreamWrapper {
-    /// pub fn get_dictionary(&self) -> Option<Vec<u8, 32768>> {
-    ///     // Per the FFI method's docs, "32768 bytes is always enough".
-    ///     let mut dict = Vec::new();
-    ///     let mut dict_view: &mut VecView<_> = &mut dict;
-    ///     let mut dict_length = 0;
-    ///     // SAFETY: When `deflateGetDictionary` returns `Z_OK`, it holds that:
-    ///     // 1. `dict_length` elements were initialized.
-    ///     // 2. `dict_length` <= the capacity (32_768)
-    ///     // which makes `set_len` safe to call.
-    ///     unsafe {
-    ///         // Make the FFI call...
-    ///         let r = deflateGetDictionary(self.strm, dict_view.as_mut_ptr(), &mut dict_length);
-    ///         if r == Z_OK {
-    ///             // ...and update the length to what was initialized.
-    ///             dict_view.set_len(dict_length);
-    ///             Some(dict)
-    ///         } else {
-    ///             None
-    ///         }
-    ///     }
-    /// }
-    /// # }
-    /// ```
-    ///
-    /// While the following example is sound, there is a memory leak since
-    /// the inner vectors were not freed prior to the `set_len` call:
-    ///
-    /// ```
-    /// use core::iter::FromIterator;
-    /// use heapless::{Vec, VecView};
-    ///
-    /// let mut vec = Vec::<Vec<u8, 3>, 3>::from_iter(
-    ///     [
-    ///         Vec::from_iter([1, 0, 0].iter().cloned()),
-    ///         Vec::from_iter([0, 1, 0].iter().cloned()),
-    ///         Vec::from_iter([0, 0, 1].iter().cloned()),
-    ///     ]
-    ///     .iter()
-    ///     .cloned(),
-    /// );
-    /// // SAFETY:
-    /// // 1. `old_len..0` is empty so no elements need to be initialized.
-    /// // 2. `0 <= capacity` always holds whatever `capacity` is.
-    /// unsafe {
-    ///     vec.as_mut_view().set_len(0);
-    /// }
-    /// ```
-    ///
-    /// Normally, here, one would use [`clear`] instead to correctly drop
-    /// the contents and thus not leak memory.
-    pub unsafe fn set_len(&mut self, new_len: usize) {
-        debug_assert!(new_len <= self.capacity());
-
-        self.len = new_len
-    }
-
-    /// Removes an element from the vector and returns it.
-    ///
-    /// The removed element is replaced by the last element of the vector.
-    ///
-    /// This does not preserve ordering, but is *O*(1).
-    ///
-    /// # Panics
-    ///
-    /// Panics if `index` is out of bounds.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use heapless::{Vec, VecView};
-    ///
-    /// let v: &mut VecView<_> = &mut Vec::<_, 8>::new();
-    /// v.push("foo").unwrap();
-    /// v.push("bar").unwrap();
-    /// v.push("baz").unwrap();
-    /// v.push("qux").unwrap();
-    ///
-    /// assert_eq!(v.swap_remove(1), "bar");
-    /// assert_eq!(v, &["foo", "qux", "baz"]);
-    ///
-    /// assert_eq!(v.swap_remove(0), "foo");
-    /// assert_eq!(v, &["baz", "qux"]);
-    /// ```
-    pub fn swap_remove(&mut self, index: usize) -> T {
-        assert!(index < self.len);
-        unsafe { self.swap_remove_unchecked(index) }
-    }
-
-    /// Removes an element from the vector and returns it.
-    ///
-    /// The removed element is replaced by the last element of the vector.
-    ///
-    /// This does not preserve ordering, but is *O*(1).
-    ///
-    /// # Safety
-    ///
-    ///  Assumes `index` within bounds.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use heapless::{Vec, VecView};
-    ///
-    /// let mut v: &mut VecView<_> = &mut Vec::<_, 8>::new();
-    /// v.push("foo").unwrap();
-    /// v.push("bar").unwrap();
-    /// v.push("baz").unwrap();
-    /// v.push("qux").unwrap();
-    ///
-    /// assert_eq!(unsafe { v.swap_remove_unchecked(1) }, "bar");
-    /// assert_eq!(v, &["foo", "qux", "baz"]);
-    ///
-    /// assert_eq!(unsafe { v.swap_remove_unchecked(0) }, "foo");
-    /// assert_eq!(v, &["baz", "qux"]);
-    /// ```
-    pub unsafe fn swap_remove_unchecked(&mut self, index: usize) -> T {
-        let length = self.len();
-        debug_assert!(index < length);
-        let value = ptr::read(self.as_ptr().add(index));
-        let base_ptr = self.as_mut_ptr();
-        ptr::copy(base_ptr.add(length - 1), base_ptr.add(index), 1);
-        self.len -= 1;
-        value
-    }
-
-    /// Returns true if the vec is full
-    #[inline]
-    pub fn is_full(&self) -> bool {
-        self.len == self.capacity()
-    }
-
-    /// Returns true if the vec is empty
-    #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.len == 0
-    }
-
-    /// Returns `true` if `needle` is a prefix of the Vec.
-    ///
-    /// Always returns `true` if `needle` is an empty slice.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use heapless::{Vec, VecView};
-    ///
-    /// let v: &VecView<_> = &Vec::<_, 8>::from_slice(b"abc").unwrap();
-    /// assert_eq!(v.starts_with(b""), true);
-    /// assert_eq!(v.starts_with(b"ab"), true);
-    /// assert_eq!(v.starts_with(b"bc"), false);
-    /// ```
-    #[inline]
-    pub fn starts_with(&self, needle: &[T]) -> bool
-    where
-        T: PartialEq,
-    {
-        let n = needle.len();
-        self.len >= n && needle == &self[..n]
-    }
-
-    /// Returns `true` if `needle` is a suffix of the Vec.
-    ///
-    /// Always returns `true` if `needle` is an empty slice.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use heapless::{Vec, VecView};
-    ///
-    /// let v: &VecView<_> = &Vec::<_, 8>::from_slice(b"abc").unwrap();
-    /// assert_eq!(v.ends_with(b""), true);
-    /// assert_eq!(v.ends_with(b"ab"), false);
-    /// assert_eq!(v.ends_with(b"bc"), true);
-    /// ```
-    #[inline]
-    pub fn ends_with(&self, needle: &[T]) -> bool
-    where
-        T: PartialEq,
-    {
-        let (v, n) = (self.len(), needle.len());
-        v >= n && needle == &self[v - n..]
-    }
-
-    /// Inserts an element at position `index` within the vector, shifting all
-    /// elements after it to the right.
-    ///
-    /// Returns back the `element` if the vector is full.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `index > len`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use heapless::{Vec, VecView};
-    ///
-    /// let mut vec: &mut VecView<_> = &mut Vec::<_, 8>::from_slice(&[1, 2, 3]).unwrap();
-    /// vec.insert(1, 4);
-    /// assert_eq!(vec, &[1, 4, 2, 3]);
-    /// vec.insert(4, 5);
-    /// assert_eq!(vec, &[1, 4, 2, 3, 5]);
-    /// ```
-    pub fn insert(&mut self, index: usize, element: T) -> Result<(), T> {
-        let len = self.len();
-        if index > len {
-            panic!(
-                "insertion index (is {}) should be <= len (is {})",
-                index, len
-            );
-        }
-
-        // check there's space for the new element
-        if self.is_full() {
-            return Err(element);
-        }
-
-        unsafe {
-            // infallible
-            // The spot to put the new value
-            {
-                let p = self.as_mut_ptr().add(index);
-                // Shift everything over to make space. (Duplicating the
-                // `index`th element into two consecutive places.)
-                ptr::copy(p, p.offset(1), len - index);
-                // Write it in, overwriting the first copy of the `index`th
-                // element.
-                ptr::write(p, element);
-            }
-            self.set_len(len + 1);
-        }
-
-        Ok(())
-    }
-
-    /// Removes and returns the element at position `index` within the vector,
-    /// shifting all elements after it to the left.
-    ///
-    /// Note: Because this shifts over the remaining elements, it has a
-    /// worst-case performance of *O*(n). If you don't need the order of
-    /// elements to be preserved, use [`swap_remove`] instead. If you'd like to
-    /// remove elements from the beginning of the `Vec`, consider using
-    /// [`Deque::pop_front`] instead.
-    ///
-    /// [`swap_remove`]: Vec::swap_remove
-    /// [`Deque::pop_front`]: crate::Deque::pop_front
-    ///
-    /// # Panics
-    ///
-    /// Panics if `index` is out of bounds.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use heapless::{Vec, VecView};
-    ///
-    /// let mut v: &mut VecView<_> = &mut Vec::<_, 8>::from_slice(&[1, 2, 3]).unwrap();
-    /// assert_eq!(v.remove(1), 2);
-    /// assert_eq!(v, &[1, 3]);
-    /// ```
-    pub fn remove(&mut self, index: usize) -> T {
-        let len = self.len();
-        if index >= len {
-            panic!("removal index (is {}) should be < len (is {})", index, len);
-        }
-        unsafe {
-            // infallible
-            let ret;
-            {
-                // the place we are taking from.
-                let ptr = self.as_mut_ptr().add(index);
-                // copy it out, unsafely having a copy of the value on
-                // the stack and in the vector at the same time.
-                ret = ptr::read(ptr);
-
-                // Shift everything down to fill in that spot.
-                ptr::copy(ptr.offset(1), ptr, len - index - 1);
-            }
-            self.set_len(len - 1);
-            ret
-        }
-    }
-
-    /// Retains only the elements specified by the predicate.
-    ///
-    /// In other words, remove all elements `e` for which `f(&e)` returns `false`.
-    /// This method operates in place, visiting each element exactly once in the
-    /// original order, and preserves the order of the retained elements.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use heapless::{Vec, VecView};
-    ///
-    /// let mut vec: &mut VecView<_> = &mut Vec::<_, 8>::from_slice(&[1, 2, 3, 4]).unwrap();
-    /// vec.retain(|&x| x % 2 == 0);
-    /// assert_eq!(vec, &[2, 4]);
-    /// ```
-    ///
-    /// Because the elements are visited exactly once in the original order,
-    /// external state may be used to decide which elements to keep.
-    ///
-    /// ```
-    /// use heapless::{Vec, VecView};
-    ///
-    /// let mut vec: &mut VecView<_> = &mut Vec::<_, 8>::from_slice(&[1, 2, 3, 4, 5]).unwrap();
-    /// let keep = [false, true, true, false, true];
-    /// let mut iter = keep.iter();
-    /// vec.retain(|_| *iter.next().unwrap());
-    /// assert_eq!(vec, &[2, 3, 5]);
-    /// ```
-    pub fn retain<F>(&mut self, mut f: F)
-    where
-        F: FnMut(&T) -> bool,
-    {
-        self.retain_mut(|elem| f(elem));
-    }
-
-    /// Retains only the elements specified by the predicate, passing a mutable reference to it.
-    ///
-    /// In other words, remove all elements `e` such that `f(&mut e)` returns `false`.
-    /// This method operates in place, visiting each element exactly once in the
-    /// original order, and preserves the order of the retained elements.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use heapless::{Vec, VecView};
-    ///
-    /// let mut vec: &mut VecView<_> = &mut Vec::<_, 8>::from_slice(&[1, 2, 3, 4]).unwrap();
-    /// vec.retain_mut(|x| {
-    ///     if *x <= 3 {
-    ///         *x += 1;
-    ///         true
-    ///     } else {
-    ///         false
-    ///     }
-    /// });
-    /// assert_eq!(vec, &[2, 3, 4]);
-    /// ```
-    pub fn retain_mut<F>(&mut self, mut f: F)
-    where
-        F: FnMut(&mut T) -> bool,
-    {
-        let original_len = self.len();
-        // Avoid double drop if the drop guard is not executed,
-        // since we may make some holes during the process.
-        unsafe { self.set_len(0) };
-
-        // Vec: [Kept, Kept, Hole, Hole, Hole, Hole, Unchecked, Unchecked]
-        //      |<-              processed len   ->| ^- next to check
-        //                  |<-  deleted cnt     ->|
-        //      |<-              original_len                          ->|
-        // Kept: Elements which predicate returns true on.
-        // Hole: Moved or dropped element slot.
-        // Unchecked: Unchecked valid elements.
-        //
-        // This drop guard will be invoked when predicate or `drop` of element panicked.
-        // It shifts unchecked elements to cover holes and `set_len` to the correct length.
-        // In cases when predicate and `drop` never panick, it will be optimized out.
-        struct BackshiftOnDrop<'a, T> {
-            v: &'a mut VecView<T>,
-            processed_len: usize,
-            deleted_cnt: usize,
-            original_len: usize,
-        }
-
-        impl<T> Drop for BackshiftOnDrop<'_, T> {
-            fn drop(&mut self) {
-                if self.deleted_cnt > 0 {
-                    // SAFETY: Trailing unchecked items must be valid since we never touch them.
-                    unsafe {
-                        ptr::copy(
-                            self.v.as_ptr().add(self.processed_len),
-                            self.v
-                                .as_mut_ptr()
-                                .add(self.processed_len - self.deleted_cnt),
-                            self.original_len - self.processed_len,
-                        );
-                    }
-                }
-                // SAFETY: After filling holes, all items are in contiguous memory.
-                unsafe {
-                    self.v.set_len(self.original_len - self.deleted_cnt);
-                }
-            }
-        }
-
-        let mut g = BackshiftOnDrop {
-            v: self,
-            processed_len: 0,
-            deleted_cnt: 0,
-            original_len,
-        };
-
-        fn process_loop<F, T, const DELETED: bool>(
-            original_len: usize,
-            f: &mut F,
-            g: &mut BackshiftOnDrop<'_, T>,
-        ) where
-            F: FnMut(&mut T) -> bool,
-        {
-            while g.processed_len != original_len {
-                let p = g.v.as_mut_ptr();
-                // SAFETY: Unchecked element must be valid.
-                let cur = unsafe { &mut *p.add(g.processed_len) };
-                if !f(cur) {
-                    // Advance early to avoid double drop if `drop_in_place` panicked.
-                    g.processed_len += 1;
-                    g.deleted_cnt += 1;
-                    // SAFETY: We never touch this element again after dropped.
-                    unsafe { ptr::drop_in_place(cur) };
-                    // We already advanced the counter.
-                    if DELETED {
-                        continue;
-                    } else {
-                        break;
-                    }
-                }
-                if DELETED {
-                    // SAFETY: `deleted_cnt` > 0, so the hole slot must not overlap with current element.
-                    // We use copy for move, and never touch this element again.
-                    unsafe {
-                        let hole_slot = p.add(g.processed_len - g.deleted_cnt);
-                        ptr::copy_nonoverlapping(cur, hole_slot, 1);
-                    }
-                }
-                g.processed_len += 1;
-            }
-        }
-
-        // Stage 1: Nothing was deleted.
-        process_loop::<F, T, false>(original_len, &mut f, &mut g);
-
-        // Stage 2: Some elements were deleted.
-        process_loop::<F, T, true>(original_len, &mut f, &mut g);
-
-        // All item are processed. This can be optimized to `set_len` by LLVM.
-        drop(g);
-    }
-
-    /// Returns the remaining spare capacity of the vector as a slice of `MaybeUninit<T>`.
-    ///
-    /// The returned slice can be used to fill the vector with data before marking the data as
-    /// initialized using the `set_len` method.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use heapless::{Vec, VecView};
-    ///
-    /// // Allocate vector big enough for 10 elements.
-    /// let mut v: Vec<_, 10> = Vec::new();
-    /// let view: &mut VecView<_> = &mut v;
-    ///
-    /// // Fill in the first 3 elements.
-    /// let uninit = view.spare_capacity_mut();
-    /// uninit[0].write(0);
-    /// uninit[1].write(1);
-    /// uninit[2].write(2);
-    ///
-    /// // Mark the first 3 elements of the vector as being initialized.
-    /// unsafe {
-    ///     view.set_len(3);
-    /// }
-    ///
-    /// assert_eq!(view, &[0, 1, 2]);
-    /// ```
-    pub fn spare_capacity_mut(&mut self) -> &mut [MaybeUninit<T>] {
-        &mut self.buffer[self.len..]
-    }
-}
-
-impl<T, const N: usize> Vec<T, N> {
-    const ELEM: MaybeUninit<T> = MaybeUninit::uninit();
-    const INIT: [MaybeUninit<T>; N] = [Self::ELEM; N]; // important for optimization of `new`
-
-    /// Constructs a new, empty vector with a fixed capacity of `N`
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use heapless::Vec;
-    ///
-    /// // allocate the vector on the stack
-    /// let mut x: Vec<u8, 16> = Vec::new();
-    ///
-    /// // allocate the vector in a static variable
-    /// static mut X: Vec<u8, 16> = Vec::new();
-    /// ```
-    pub const fn new() -> Self {
-        Self {
-            len: 0,
-            buffer: Self::INIT,
-        }
-    }
-
-    /// Constructs a new vector with a fixed capacity of `N` and fills it
-    /// with the provided slice.
-    ///
-    /// This is equivalent to the following code:
-    ///
-    /// ```
-    /// use heapless::Vec;
-    ///
-    /// let mut v: Vec<u8, 16> = Vec::new();
-    /// v.extend_from_slice(&[1, 2, 3]).unwrap();
-    /// ```
-    #[inline]
-    #[allow(clippy::result_unit_err)]
-    pub fn from_slice(other: &[T]) -> Result<Self, ()>
-    where
-        T: Clone,
-    {
-        let mut v = Vec::new();
-        v.extend_from_slice(other)?;
-        Ok(v)
-    }
-
-    /// Constructs a new vector with a fixed capacity of `N`, initializing
-    /// it with the provided array.
-    ///
-    /// The length of the provided array, `M` may be equal to _or_ less than
-    /// the capacity of the vector, `N`.
-    ///
-    /// If the length of the provided array is greater than the capacity of the
-    /// vector a compile-time error will be produced.
-    pub fn from_array<const M: usize>(src: [T; M]) -> Self {
-        // Const assert M >= 0
-        crate::sealed::greater_than_eq_0::<M>();
-        // Const assert N >= M
-        crate::sealed::greater_than_eq::<N, M>();
-
-        // We've got to copy `src`, but we're functionally moving it. Don't run
-        // any Drop code for T.
-        let src = ManuallyDrop::new(src);
-
-        if N == M {
-            Self {
-                len: N,
-                // NOTE(unsafe) ManuallyDrop<[T; M]> and [MaybeUninit<T>; N]
-                // have the same layout when N == M.
-                buffer: unsafe { mem::transmute_copy(&src) },
-            }
-        } else {
-            let mut v = Vec::<T, N>::new();
-
-            for (src_elem, dst_elem) in src.iter().zip(v.buffer.iter_mut()) {
-                // NOTE(unsafe) src element is not going to drop as src itself
-                // is wrapped in a ManuallyDrop.
-                dst_elem.write(unsafe { ptr::read(src_elem) });
-            }
-
-            v.len = M;
-            v
-        }
-    }
-
-    /// Clones a vec into a new vec
-    pub(crate) fn clone(&self) -> Self
-    where
-        T: Clone,
-    {
-        let mut new = Self::new();
-        // avoid `extend_from_slice` as that introduces a runtime check/panicking branch
-        for elem in self {
-            unsafe {
-                new.push_unchecked(elem.clone());
-            }
-        }
-        new
-    }
-
-    /// Get a reference to the `Vec`, erasing the `N` const-generic.
-    ///
-    ///
-    /// ```rust
-    /// # use heapless::{Vec, VecView};
-    /// let vec: Vec<u8, 10> = Vec::from_slice(&[1, 2, 3, 4]).unwrap();
-    /// let view: &VecView<u8> = vec.as_view();
-    /// ```
-    ///
-    /// It is often preferable to do the same through type coerction, since `Vec<T, N>` implements `Unsize<VecView<T>>`:
-    ///
-    /// ```rust
-    /// # use heapless::{Vec, VecView};
-    /// let vec: Vec<u8, 10> = Vec::from_slice(&[1, 2, 3, 4]).unwrap();
-    /// let view: &VecView<u8> = &vec;
-    /// ```
-    #[inline]
-    pub const fn as_view(&self) -> &VecView<T> {
-        self
-    }
-
-    /// Get a mutable reference to the `Vec`, erasing the `N` const-generic.
-    ///
-    /// ```rust
-    /// # use heapless::{Vec, VecView};
-    /// let mut vec: Vec<u8, 10> = Vec::from_slice(&[1, 2, 3, 4]).unwrap();
-    /// let view: &mut VecView<u8> = vec.as_mut_view();
-    /// ```
-    ///
-    /// It is often preferable to do the same through type coerction, since `Vec<T, N>` implements `Unsize<VecView<T>>`:
-    ///
-    /// ```rust
-    /// # use heapless::{Vec, VecView};
-    /// let mut vec: Vec<u8, 10> = Vec::from_slice(&[1, 2, 3, 4]).unwrap();
-    /// let view: &mut VecView<u8> = &mut vec;
-    /// ```
-    #[inline]
-    pub fn as_mut_view(&mut self) -> &mut VecView<T> {
-        self
-    }
-
-    /// Extracts a slice containing the entire vector.
-    ///
-    /// Equivalent to `&s[..]`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use heapless::Vec;
-    /// let buffer: Vec<u8, 5> = Vec::from_slice(&[1, 2, 3, 5, 8]).unwrap();
-    /// assert_eq!(buffer.as_slice(), &[1, 2, 3, 5, 8]);
-    /// ```
-    #[inline]
-    pub fn as_slice(&self) -> &[T] {
-        self.as_view().as_slice()
-    }
-
-    /// Returns the contents of the vector as an array of length `M` if the length
-    /// of the vector is exactly `M`, otherwise returns `Err(self)`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use heapless::Vec;
-    /// let buffer: Vec<u8, 42> = Vec::from_slice(&[1, 2, 3, 5, 8]).unwrap();
-    /// let array: [u8; 5] = buffer.into_array().unwrap();
-    /// assert_eq!(array, [1, 2, 3, 5, 8]);
-    /// ```
-    pub fn into_array<const M: usize>(self) -> Result<[T; M], Self> {
-        if self.len() == M {
-            // This is how the unstable `MaybeUninit::array_assume_init` method does it
-            let array = unsafe { (&self.buffer as *const _ as *const [T; M]).read() };
-
-            // We don't want `self`'s destructor to be called because that would drop all the
-            // items in the array
-            core::mem::forget(self);
-
-            Ok(array)
-        } else {
-            Err(self)
-        }
-    }
-
-    /// Extracts a mutable slice containing the entire vector.
-    ///
-    /// Equivalent to `&mut s[..]`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use heapless::Vec;
-    /// let mut buffer: Vec<u8, 5> = Vec::from_slice(&[1, 2, 3, 5, 8]).unwrap();
-    /// let buffer_slice = buffer.as_mut_slice();
-    /// buffer_slice[0] = 9;
-    /// assert_eq!(buffer.as_slice(), &[9, 2, 3, 5, 8]);
-    /// ```
-    #[inline]
-    pub fn as_mut_slice(&mut self) -> &mut [T] {
-        self.as_mut_view().as_mut_slice()
-    }
-
-    /// Returns the maximum number of elements the vector can hold.
-    pub const fn capacity(&self) -> usize {
-        N
-    }
-
-    /// Clears the vector, removing all values.
-    #[inline]
-    pub fn clear(&mut self) {
-        self.as_mut_view().clear()
-    }
-
-    /// Extends the vec from an iterator.
-    ///
-    /// # Panic
-    ///
-    /// Panics if the vec cannot hold all elements of the iterator.
-    #[inline]
-    pub fn extend<I>(&mut self, iter: I)
-    where
-        I: IntoIterator<Item = T>,
-    {
-        self.as_mut_view().extend(iter)
-    }
-
-    /// Clones and appends all elements in a slice to the `Vec`.
-    ///
-    /// Iterates over the slice `other`, clones each element, and then appends
-    /// it to this `Vec`. The `other` vector is traversed in-order.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use heapless::Vec;
-    ///
-    /// let mut vec = Vec::<u8, 8>::new();
-    /// vec.push(1).unwrap();
-    /// vec.extend_from_slice(&[2, 3, 4]).unwrap();
-    /// assert_eq!(*vec, [1, 2, 3, 4]);
-    /// ```
-    #[allow(clippy::result_unit_err)]
-    #[inline]
-    pub fn extend_from_slice(&mut self, other: &[T]) -> Result<(), ()>
-    where
-        T: Clone,
-    {
-        self.as_mut_view().extend_from_slice(other)
-    }
-
-    /// Removes the last element from a vector and returns it, or `None` if it's empty
-    #[inline]
-    pub fn pop(&mut self) -> Option<T> {
-        self.as_mut_view().pop()
-    }
-
-    /// Appends an `item` to the back of the collection
-    ///
-    /// Returns back the `item` if the vector is full.
-    #[inline]
-    pub fn push(&mut self, item: T) -> Result<(), T> {
-        self.as_mut_view().push(item)
-    }
-
-    /// Removes the last element from a vector and returns it
-    ///
-    /// # Safety
-    ///
-    /// This assumes the vec to have at least one element.
-    #[inline]
-    pub unsafe fn pop_unchecked(&mut self) -> T {
-        self.as_mut_view().pop_unchecked()
-    }
-
-    /// Appends an `item` to the back of the collection
-    ///
-    /// # Safety
-    ///
-    /// This assumes the vec is not full.
-    #[inline]
-    pub unsafe fn push_unchecked(&mut self, item: T) {
-        self.as_mut_view().push_unchecked(item)
-    }
-
-    /// Shortens the vector, keeping the first `len` elements and dropping the rest.
-    #[inline]
-    pub fn truncate(&mut self, len: usize) {
-        self.as_mut_view().truncate(len)
-    }
-
-    /// Resizes the Vec in-place so that len is equal to new_len.
-    ///
-    /// If new_len is greater than len, the Vec is extended by the
-    /// difference, with each additional slot filled with value. If
-    /// new_len is less than len, the Vec is simply truncated.
-    ///
-    /// See also [`resize_default`](Self::resize_default).
-    #[allow(clippy::result_unit_err)]
-    #[inline]
-    pub fn resize(&mut self, new_len: usize, value: T) -> Result<(), ()>
-    where
-        T: Clone,
-    {
-        self.as_mut_view().resize(new_len, value)
-    }
-
-    /// Resizes the `Vec` in-place so that `len` is equal to `new_len`.
-    ///
-    /// If `new_len` is greater than `len`, the `Vec` is extended by the
-    /// difference, with each additional slot filled with `Default::default()`.
-    /// If `new_len` is less than `len`, the `Vec` is simply truncated.
-    ///
-    /// See also [`resize`](Self::resize).
-    #[allow(clippy::result_unit_err)]
-    #[inline]
-    pub fn resize_default(&mut self, new_len: usize) -> Result<(), ()>
-    where
-        T: Clone + Default,
-    {
-        self.as_mut_view().resize_default(new_len)
     }
 
     /// Forces the length of the vector to `new_len`.
@@ -1276,9 +593,9 @@ impl<T, const N: usize> Vec<T, N> {
     /// assert_eq!(v.swap_remove(0), "foo");
     /// assert_eq!(&*v, ["baz", "qux"]);
     /// ```
-    #[inline]
     pub fn swap_remove(&mut self, index: usize) -> T {
-        self.as_mut_view().swap_remove(index)
+        assert!(index < self.len);
+        unsafe { self.swap_remove_unchecked(index) }
     }
 
     /// Removes an element from the vector and returns it.
@@ -1308,19 +625,22 @@ impl<T, const N: usize> Vec<T, N> {
     /// assert_eq!(unsafe { v.swap_remove_unchecked(0) }, "foo");
     /// assert_eq!(&*v, ["baz", "qux"]);
     /// ```
-    #[inline]
     pub unsafe fn swap_remove_unchecked(&mut self, index: usize) -> T {
-        self.as_mut_view().swap_remove_unchecked(index)
+        let length = self.len();
+        debug_assert!(index < length);
+        let value = ptr::read(self.as_ptr().add(index));
+        let base_ptr = self.as_mut_ptr();
+        ptr::copy(base_ptr.add(length - 1), base_ptr.add(index), 1);
+        self.len -= 1;
+        value
     }
 
     /// Returns true if the vec is full
-    #[inline]
     pub fn is_full(&self) -> bool {
         self.len == self.capacity()
     }
 
     /// Returns true if the vec is empty
-    #[inline]
     pub fn is_empty(&self) -> bool {
         self.len == 0
     }
@@ -1339,7 +659,6 @@ impl<T, const N: usize> Vec<T, N> {
     /// assert_eq!(v.starts_with(b"ab"), true);
     /// assert_eq!(v.starts_with(b"bc"), false);
     /// ```
-    #[inline]
     pub fn starts_with(&self, needle: &[T]) -> bool
     where
         T: PartialEq,
@@ -1362,7 +681,6 @@ impl<T, const N: usize> Vec<T, N> {
     /// assert_eq!(v.ends_with(b"ab"), false);
     /// assert_eq!(v.ends_with(b"bc"), true);
     /// ```
-    #[inline]
     pub fn ends_with(&self, needle: &[T]) -> bool
     where
         T: PartialEq,
@@ -1391,9 +709,36 @@ impl<T, const N: usize> Vec<T, N> {
     /// vec.insert(4, 5);
     /// assert_eq!(vec, [1, 4, 2, 3, 5]);
     /// ```
-    #[inline]
     pub fn insert(&mut self, index: usize, element: T) -> Result<(), T> {
-        self.as_mut_view().insert(index, element)
+        let len = self.len();
+        if index > len {
+            panic!(
+                "insertion index (is {}) should be <= len (is {})",
+                index, len
+            );
+        }
+
+        // check there's space for the new element
+        if self.is_full() {
+            return Err(element);
+        }
+
+        unsafe {
+            // infallible
+            // The spot to put the new value
+            {
+                let p = self.as_mut_ptr().add(index);
+                // Shift everything over to make space. (Duplicating the
+                // `index`th element into two consecutive places.)
+                ptr::copy(p, p.offset(1), len - index);
+                // Write it in, overwriting the first copy of the `index`th
+                // element.
+                ptr::write(p, element);
+            }
+            self.set_len(len + 1);
+        }
+
+        Ok(())
     }
 
     /// Removes and returns the element at position `index` within the vector,
@@ -1421,9 +766,27 @@ impl<T, const N: usize> Vec<T, N> {
     /// assert_eq!(v.remove(1), 2);
     /// assert_eq!(v, [1, 3]);
     /// ```
-    #[inline]
     pub fn remove(&mut self, index: usize) -> T {
-        self.as_mut_view().remove(index)
+        let len = self.len();
+        if index >= len {
+            panic!("removal index (is {}) should be < len (is {})", index, len);
+        }
+        unsafe {
+            // infallible
+            let ret;
+            {
+                // the place we are taking from.
+                let ptr = self.as_mut_ptr().add(index);
+                // copy it out, unsafely having a copy of the value on
+                // the stack and in the vector at the same time.
+                ret = ptr::read(ptr);
+
+                // Shift everything down to fill in that spot.
+                ptr::copy(ptr.offset(1), ptr, len - index - 1);
+            }
+            self.set_len(len - 1);
+            ret
+        }
     }
 
     /// Retains only the elements specified by the predicate.
@@ -1454,12 +817,11 @@ impl<T, const N: usize> Vec<T, N> {
     /// vec.retain(|_| *iter.next().unwrap());
     /// assert_eq!(vec, [2, 3, 5]);
     /// ```
-    #[inline]
-    pub fn retain<F>(&mut self, f: F)
+    pub fn retain<F>(&mut self, mut f: F)
     where
         F: FnMut(&T) -> bool,
     {
-        self.as_mut_view().retain(f)
+        self.retain_mut(|elem| f(elem));
     }
 
     /// Retains only the elements specified by the predicate, passing a mutable reference to it.
@@ -1484,12 +846,105 @@ impl<T, const N: usize> Vec<T, N> {
     /// });
     /// assert_eq!(vec, [2, 3, 4]);
     /// ```
-    #[inline]
-    pub fn retain_mut<F>(&mut self, f: F)
+    pub fn retain_mut<F>(&mut self, mut f: F)
     where
         F: FnMut(&mut T) -> bool,
     {
-        self.as_mut_view().retain_mut(f)
+        let original_len = self.len();
+        // Avoid double drop if the drop guard is not executed,
+        // since we may make some holes during the process.
+        unsafe { self.set_len(0) };
+
+        // Vec: [Kept, Kept, Hole, Hole, Hole, Hole, Unchecked, Unchecked]
+        //      |<-              processed len   ->| ^- next to check
+        //                  |<-  deleted cnt     ->|
+        //      |<-              original_len                          ->|
+        // Kept: Elements which predicate returns true on.
+        // Hole: Moved or dropped element slot.
+        // Unchecked: Unchecked valid elements.
+        //
+        // This drop guard will be invoked when predicate or `drop` of element panicked.
+        // It shifts unchecked elements to cover holes and `set_len` to the correct length.
+        // In cases when predicate and `drop` never panick, it will be optimized out.
+        struct BackshiftOnDrop<'a, T, S: Storage> {
+            v: &'a mut VecInner<T, S>,
+            processed_len: usize,
+            deleted_cnt: usize,
+            original_len: usize,
+        }
+
+        impl<'a, T, S: Storage> Drop for BackshiftOnDrop<'a, T, S> {
+            fn drop(&mut self) {
+                if self.deleted_cnt > 0 {
+                    // SAFETY: Trailing unchecked items must be valid since we never touch them.
+                    unsafe {
+                        ptr::copy(
+                            self.v.as_ptr().add(self.processed_len),
+                            self.v
+                                .as_mut_ptr()
+                                .add(self.processed_len - self.deleted_cnt),
+                            self.original_len - self.processed_len,
+                        );
+                    }
+                }
+                // SAFETY: After filling holes, all items are in contiguous memory.
+                unsafe {
+                    self.v.set_len(self.original_len - self.deleted_cnt);
+                }
+            }
+        }
+
+        let mut g = BackshiftOnDrop {
+            v: self,
+            processed_len: 0,
+            deleted_cnt: 0,
+            original_len,
+        };
+
+        fn process_loop<F, T, S: Storage, const DELETED: bool>(
+            original_len: usize,
+            f: &mut F,
+            g: &mut BackshiftOnDrop<'_, T, S>,
+        ) where
+            F: FnMut(&mut T) -> bool,
+        {
+            while g.processed_len != original_len {
+                let p = g.v.as_mut_ptr();
+                // SAFETY: Unchecked element must be valid.
+                let cur = unsafe { &mut *p.add(g.processed_len) };
+                if !f(cur) {
+                    // Advance early to avoid double drop if `drop_in_place` panicked.
+                    g.processed_len += 1;
+                    g.deleted_cnt += 1;
+                    // SAFETY: We never touch this element again after dropped.
+                    unsafe { ptr::drop_in_place(cur) };
+                    // We already advanced the counter.
+                    if DELETED {
+                        continue;
+                    } else {
+                        break;
+                    }
+                }
+                if DELETED {
+                    // SAFETY: `deleted_cnt` > 0, so the hole slot must not overlap with current element.
+                    // We use copy for move, and never touch this element again.
+                    unsafe {
+                        let hole_slot = p.add(g.processed_len - g.deleted_cnt);
+                        ptr::copy_nonoverlapping(cur, hole_slot, 1);
+                    }
+                }
+                g.processed_len += 1;
+            }
+        }
+
+        // Stage 1: Nothing was deleted.
+        process_loop::<F, T, S, false>(original_len, &mut f, &mut g);
+
+        // Stage 2: Some elements were deleted.
+        process_loop::<F, T, S, true>(original_len, &mut f, &mut g);
+
+        // All item are processed. This can be optimized to `set_len` by LLVM.
+        drop(g);
     }
 
     /// Returns the remaining spare capacity of the vector as a slice of `MaybeUninit<T>`.
@@ -1520,7 +975,7 @@ impl<T, const N: usize> Vec<T, N> {
     /// ```
     #[inline]
     pub fn spare_capacity_mut(&mut self) -> &mut [MaybeUninit<T>] {
-        self.as_mut_view().spare_capacity_mut()
+        &mut self.buffer.borrow_mut()[self.len..]
     }
 }
 
@@ -1532,7 +987,7 @@ impl<T, const N: usize> Default for Vec<T, N> {
     }
 }
 
-impl<T> fmt::Debug for VecView<T>
+impl<T, S: Storage> fmt::Debug for VecInner<T, S>
 where
     T: fmt::Debug,
 {
@@ -1541,26 +996,7 @@ where
     }
 }
 
-impl<T, const N: usize> fmt::Debug for Vec<T, N>
-where
-    T: fmt::Debug,
-{
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.as_view().fmt(f)
-    }
-}
-
-impl<const N: usize> fmt::Write for Vec<u8, N> {
-    fn write_str(&mut self, s: &str) -> fmt::Result {
-        match self.extend_from_slice(s.as_bytes()) {
-            Ok(()) => Ok(()),
-            Err(_) => Err(fmt::Error),
-        }
-    }
-}
-
-impl fmt::Write for VecView<u8> {
+impl<S: Storage> fmt::Write for VecInner<u8, S> {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         match self.extend_from_slice(s.as_bytes()) {
             Ok(()) => Ok(()),
@@ -1575,9 +1011,9 @@ impl<T, const N: usize, const M: usize> From<[T; M]> for Vec<T, N> {
     }
 }
 
-impl<T: ?Sized + VecBuffer> Drop for VecInner<T> {
+impl<T, S: Storage> Drop for VecInner<T, S> {
     fn drop(&mut self) {
-        let mut_slice = VecBuffer::as_mut_vecview(self).as_mut_slice();
+        let mut_slice = self.as_mut_slice();
         // We drop each element used in the vector by turning into a `&mut [T]`.
         // SAFETY: the buffer contains initialized data for the range 0..self.len
         unsafe { ptr::drop_in_place(mut_slice) }
@@ -1592,7 +1028,7 @@ impl<'a, T: Clone, const N: usize> TryFrom<&'a [T]> for Vec<T, N> {
     }
 }
 
-impl<T> Extend<T> for VecView<T> {
+impl<T, S: Storage> Extend<T> for VecInner<T, S> {
     fn extend<I>(&mut self, iter: I)
     where
         I: IntoIterator<Item = T>,
@@ -1601,28 +1037,7 @@ impl<T> Extend<T> for VecView<T> {
     }
 }
 
-impl<T, const N: usize> Extend<T> for Vec<T, N> {
-    fn extend<I>(&mut self, iter: I)
-    where
-        I: IntoIterator<Item = T>,
-    {
-        self.as_mut_view().extend(iter)
-    }
-}
-
-impl<'a, T, const N: usize> Extend<&'a T> for Vec<T, N>
-where
-    T: 'a + Copy,
-{
-    fn extend<I>(&mut self, iter: I)
-    where
-        I: IntoIterator<Item = &'a T>,
-    {
-        self.as_mut_view().extend(iter.into_iter().cloned())
-    }
-}
-
-impl<'a, T> Extend<&'a T> for VecView<T>
+impl<'a, T, S: Storage> Extend<&'a T> for VecInner<T, S>
 where
     T: 'a + Copy,
 {
@@ -1634,16 +1049,7 @@ where
     }
 }
 
-impl<T, const N: usize> hash::Hash for Vec<T, N>
-where
-    T: core::hash::Hash,
-{
-    fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        self.as_view().hash(state)
-    }
-}
-
-impl<T> hash::Hash for VecView<T>
+impl<T, S: Storage> hash::Hash for VecInner<T, S>
 where
     T: core::hash::Hash,
 {
@@ -1652,16 +1058,7 @@ where
     }
 }
 
-impl<'a, T, const N: usize> IntoIterator for &'a Vec<T, N> {
-    type Item = &'a T;
-    type IntoIter = slice::Iter<'a, T>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.as_view().iter()
-    }
-}
-
-impl<'a, T> IntoIterator for &'a VecView<T> {
+impl<'a, T, S: Storage> IntoIterator for &'a VecInner<T, S> {
     type Item = &'a T;
     type IntoIter = slice::Iter<'a, T>;
 
@@ -1670,16 +1067,7 @@ impl<'a, T> IntoIterator for &'a VecView<T> {
     }
 }
 
-impl<'a, T, const N: usize> IntoIterator for &'a mut Vec<T, N> {
-    type Item = &'a mut T;
-    type IntoIter = slice::IterMut<'a, T>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.as_mut_view().iter_mut()
-    }
-}
-
-impl<'a, T> IntoIterator for &'a mut VecView<T> {
+impl<'a, T, S: Storage> IntoIterator for &'a mut VecInner<T, S> {
     type Item = &'a mut T;
     type IntoIter = slice::IterMut<'a, T>;
 
@@ -1763,185 +1151,173 @@ impl<T, const N: usize> IntoIterator for Vec<T, N> {
     }
 }
 
-macro_rules! impl_cmp_traits {
-    ($Ty:ident<$T:ident $(, const $M:ident : usize, const $N:ident : usize)?>) => {
-        impl<A, B$(, const $M: usize)*, const N: usize> PartialEq<Vec<B, N>> for $Ty<A$(, $M)*>
-        where
-            A: PartialEq<B>,
-        {
-            #[inline]
-            fn eq(&self, other: &Vec<B, N>) -> bool {
-                self.as_slice().eq(other.as_slice())
-            }
-        }
-
-        impl<A, B$(, const $N: usize)*> PartialEq<VecView<B>> for $Ty<A$(, $N)*>
-        where
-            A: PartialEq<B>,
-        {
-            #[inline]
-            fn eq(&self, other: &VecView<B>) -> bool {
-                self.as_slice().eq(other.as_slice())
-            }
-        }
-
-        impl<A, B, const M: usize$(, const $N: usize)*> PartialEq<$Ty<B$(, $N)*>> for [A; M]
-        where
-            A: PartialEq<B>,
-        {
-            #[inline]
-            fn eq(&self, other: &$Ty<B$(, $N)*>) -> bool {
-                self.eq(other.as_slice())
-            }
-        }
-
-        impl<A, B, const M: usize$(, const $N: usize)*> PartialEq<$Ty<B$(, $N)*>> for &[A; M]
-        where
-            A: PartialEq<B>,
-        {
-            #[inline]
-            fn eq(&self, other: &$Ty<B$(, $N)*>) -> bool {
-                (*self).eq(other)
-            }
-        }
-
-        impl<A, B$(, const $N: usize)*> PartialEq<$Ty<B$(, $N)*>> for [A]
-        where
-            A: PartialEq<B>,
-        {
-            #[inline]
-            fn eq(&self, other: &$Ty<B$(, $N)*>) -> bool {
-                self.eq(other.as_slice())
-            }
-        }
-
-        impl<A, B$(, const $N: usize)*> PartialEq<$Ty<B$(, $N)*>> for &[A]
-        where
-            A: PartialEq<B>,
-        {
-            #[inline]
-            fn eq(&self, other: &$Ty<B$(, $N)*>) -> bool {
-                (*self).eq(other)
-            }
-        }
-
-        impl<A, B$(, const $M: usize)*, const N: usize> PartialEq<[B; N]> for $Ty<A$(, $M)*>
-        where
-            A: PartialEq<B>,
-        {
-            #[inline]
-            fn eq(&self, other: &[B; N]) -> bool {
-                self.as_slice().eq(other.as_slice())
-            }
-        }
-
-        impl<A, B$(, const $M: usize)*, const N: usize> PartialEq<&[B; N]> for $Ty<A$(, $M)*>
-        where
-            A: PartialEq<B>,
-        {
-            #[inline]
-            fn eq(&self, other: &&[B; N]) -> bool {
-                self.as_slice().eq(other.as_slice())
-            }
-        }
-
-        impl<A, B$(, const $N: usize)*> PartialEq<[B]> for $Ty<A$(, $N)*>
-        where
-            A: PartialEq<B>,
-        {
-            #[inline]
-            fn eq(&self, other: &[B]) -> bool {
-                self.as_slice().eq(other)
-            }
-        }
-
-        impl<A, B$(, const $N: usize)*> PartialEq<&[B]> for $Ty<A$(, $N)*>
-        where
-            A: PartialEq<B>,
-        {
-            #[inline]
-            fn eq(&self, other: &&[B]) -> bool {
-                self.as_slice().eq(*other)
-            }
-        }
-
-        impl<T $(, const $N: usize)*> Eq for $Ty<T$(, $N)*> where T: Eq {}
-
-        impl<T $(, const $M: usize, const $N: usize)*> PartialOrd<$Ty<T$(, $N)*>> for $Ty<T$(, $M)*>
-        where
-            T: PartialOrd
-        {
-            #[inline]
-            fn partial_cmp(&self, other: &$Ty<T$(, $N)*>) -> Option<Ordering> {
-                self.as_slice().partial_cmp(other.as_slice())
-            }
-        }
-
-        impl<T $(, const $N: usize)*> Ord for $Ty<T$(, $N)*>
-        where
-            T: Ord
-        {
-            #[inline]
-            fn cmp(&self, other: &Self) -> Ordering {
-                self.as_slice().cmp(other.as_slice())
-            }
-        }
+impl<A, B, SA: Storage, SB: Storage> PartialEq<VecInner<B, SB>> for VecInner<A, SA>
+where
+    A: PartialEq<B>,
+{
+    fn eq(&self, other: &VecInner<B, SB>) -> bool {
+        self.as_slice().eq(other.as_slice())
     }
 }
 
-impl_cmp_traits!(VecView<T>);
-impl_cmp_traits!(Vec<T, const M: usize, const N: usize>);
-
-macro_rules! impl_ref_traits {
-    ($Ty:ident<$T:ident $(, const $N:ident : usize)?>) => {
-        impl<T $(, const $N: usize)*> ops::Deref for $Ty<T$(, $N)*> {
-            type Target = [T];
-
-            #[inline]
-            fn deref(&self) -> &Self::Target {
-                self.as_slice()
-            }
-        }
-
-        impl<T $(, const $N: usize)*> ops::DerefMut for $Ty<T$(, $N)*> {
-          #[inline]
-            fn deref_mut(&mut self) -> &mut Self::Target {
-                self.as_mut_slice()
-            }
-        }
-
-        impl<T $(, const $N: usize)*> AsRef<$Ty<T$(, $N)*>> for $Ty<T$(, $N)*> {
-            #[inline]
-            fn as_ref(&self) -> &Self {
-                self
-            }
-        }
-
-        impl<T $(, const $N: usize)*> AsMut<$Ty<T$(, $N)*>> for $Ty<T$(, $N)*> {
-            #[inline]
-            fn as_mut(&mut self) -> &mut Self {
-                self
-            }
-        }
-
-        impl<T $(, const $N: usize)*> AsRef<[T]> for $Ty<T$(, $N)*> {
-            #[inline]
-            fn as_ref(&self) -> &[T] {
-                self
-            }
-        }
-
-        impl<T $(, const $N: usize)*> AsMut<[T]> for $Ty<T$(, $N)*> {
-            #[inline]
-            fn as_mut(&mut self) -> &mut [T] {
-                self
-            }
-        }
-    };
+impl<A, B, const M: usize, SB: Storage> PartialEq<VecInner<B, SB>> for [A; M]
+where
+    A: PartialEq<B>,
+{
+    fn eq(&self, other: &VecInner<B, SB>) -> bool {
+        self.eq(other.as_slice())
+    }
 }
 
-impl_ref_traits!(VecView<T>);
-impl_ref_traits!(Vec<T, const N: usize>);
+impl<A, B, SB: Storage, const M: usize> PartialEq<VecInner<B, SB>> for &[A; M]
+where
+    A: PartialEq<B>,
+{
+    fn eq(&self, other: &VecInner<B, SB>) -> bool {
+        (*self).eq(other)
+    }
+}
+
+impl<A, B, SB: Storage> PartialEq<VecInner<B, SB>> for [A]
+where
+    A: PartialEq<B>,
+{
+    fn eq(&self, other: &VecInner<B, SB>) -> bool {
+        self.eq(other.as_slice())
+    }
+}
+
+impl<A, B, SB: Storage> PartialEq<VecInner<B, SB>> for &[A]
+where
+    A: PartialEq<B>,
+{
+    fn eq(&self, other: &VecInner<B, SB>) -> bool {
+        (*self).eq(other)
+    }
+}
+
+impl<A, B, SB: Storage> PartialEq<VecInner<B, SB>> for &mut [A]
+where
+    A: PartialEq<B>,
+{
+    fn eq(&self, other: &VecInner<B, SB>) -> bool {
+        (**self).eq(other)
+    }
+}
+
+impl<A, B, SA: Storage, const N: usize> PartialEq<[B; N]> for VecInner<A, SA>
+where
+    A: PartialEq<B>,
+{
+    #[inline]
+    fn eq(&self, other: &[B; N]) -> bool {
+        self.as_slice().eq(other.as_slice())
+    }
+}
+
+impl<A, B, SA: Storage, const N: usize> PartialEq<&[B; N]> for VecInner<A, SA>
+where
+    A: PartialEq<B>,
+{
+    #[inline]
+    fn eq(&self, other: &&[B; N]) -> bool {
+        self.as_slice().eq(other.as_slice())
+    }
+}
+
+impl<A, B, SA: Storage> PartialEq<[B]> for VecInner<A, SA>
+where
+    A: PartialEq<B>,
+{
+    #[inline]
+    fn eq(&self, other: &[B]) -> bool {
+        self.as_slice().eq(other)
+    }
+}
+
+impl<A, B, SA: Storage> PartialEq<&[B]> for VecInner<A, SA>
+where
+    A: PartialEq<B>,
+{
+    #[inline]
+    fn eq(&self, other: &&[B]) -> bool {
+        self.as_slice().eq(*other)
+    }
+}
+
+impl<A, B, SA: Storage> PartialEq<&mut [B]> for VecInner<A, SA>
+where
+    A: PartialEq<B>,
+{
+    #[inline]
+    fn eq(&self, other: &&mut [B]) -> bool {
+        self.as_slice().eq(*other)
+    }
+}
+
+// Implements Eq if underlying data is Eq
+impl<T, S: Storage> Eq for VecInner<T, S> where T: Eq {}
+
+impl<T, SA: Storage, SB: Storage> PartialOrd<VecInner<T, SA>> for VecInner<T, SB>
+where
+    T: PartialOrd,
+{
+    fn partial_cmp(&self, other: &VecInner<T, SA>) -> Option<Ordering> {
+        self.as_slice().partial_cmp(other.as_slice())
+    }
+}
+
+impl<T, S: Storage> Ord for VecInner<T, S>
+where
+    T: Ord,
+{
+    #[inline]
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.as_slice().cmp(other.as_slice())
+    }
+}
+
+impl<T, S: Storage> ops::Deref for VecInner<T, S> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+impl<T, S: Storage> ops::DerefMut for VecInner<T, S> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.as_mut_slice()
+    }
+}
+
+impl<T, S: Storage> AsRef<VecInner<T, S>> for VecInner<T, S> {
+    #[inline]
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
+impl<T, S: Storage> AsMut<VecInner<T, S>> for VecInner<T, S> {
+    #[inline]
+    fn as_mut(&mut self) -> &mut Self {
+        self
+    }
+}
+
+impl<T, S: Storage> AsRef<[T]> for VecInner<T, S> {
+    #[inline]
+    fn as_ref(&self) -> &[T] {
+        self
+    }
+}
+
+impl<T, S: Storage> AsMut<[T]> for VecInner<T, S> {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [T] {
+        self
+    }
+}
 
 impl<T, const N: usize> Clone for Vec<T, N>
 where
@@ -2025,7 +1401,8 @@ mod tests {
 
         {
             let v: Vec<Droppable, 2> = Vec::new();
-            let mut v: Box<VecView<Droppable>> = Box::new(v);
+            let v: Box<Vec<Droppable, 2>> = Box::new(v);
+            let mut v: Box<VecView<Droppable>> = v;
             v.push(Droppable::new()).ok().unwrap();
             v.push(Droppable::new()).ok().unwrap();
             assert_eq!(Droppable::count(), 2);
@@ -2037,7 +1414,8 @@ mod tests {
 
         {
             let v: Vec<Droppable, 2> = Vec::new();
-            let mut v: Box<VecView<Droppable>> = Box::new(v);
+            let v: Box<Vec<Droppable, 2>> = Box::new(v);
+            let mut v: Box<VecView<Droppable>> = v;
             v.push(Droppable::new()).ok().unwrap();
             v.push(Droppable::new()).ok().unwrap();
             assert_eq!(Droppable::count(), 2);


### PR DESCRIPTION
I'm a bit concerned about the code duplication introduced by #425. Most `Vec`
methods forward to their `VecView` counterparts, but the function signature
and the doc comments are still duplicated. This means every time we do a doc
fix or add a new method we have to remember to do it on both sides.

It has worked fine for for experimenting and proving the concept. However,
now we're at a stage where it's proven and we have to commit to
add it to all the other containers: #452 #459 #479 #480 #481 #485.
Each of these PRs adds 400-600 lines to the codebase, mostly duplicated
signatures and docs.

IMO we should find a way of adding `View` types without so much duplication
first, *then* add it to all containers.

This PR implements a possible solution I've found that removes all the duplication:

- Added a `Storage` trait with two impls, for sized and unsized.
- Vec is now generic over `Storage` instead of over the buffer type. The buffer type is now a `Buffer` associated type.
- `Storage` is sealed. The `Buffer` associated type is private. The user cannot learn the `Buffer` type for the 
  `Storage` impls, they can just use it with `VecInner` and it makes it behave differently magically.
- Most methods are implemented for `VecInner<S>` for any `S: Storage`. This makes them
  available on both `Vec` and `VecView` without duplicating anything.

Advantages:
- No duplication.
- No macros.
- Trait impls are generic over `Storage` now, so you can e.g. compare a `Vec` with a `VecView`. Before you couldn't, you could only do `Vec-Vec` or `VecView-VecView`.
- Users can now write code or trait impls generic over the storage.

Docs work fine on latest stable, it doesn't seem to need any workarounds:
- docs for `Vec` show the `Vec`-only methods and the storage-independent methods.
- docs for `VecView` show the `VecView`-only methods (if we had some, we don't) and the storage-independent methods.
- docs for `Vecinner` show all methods.

I also propose making `mod vec` public, including `Storage, VecInner`. The reasons are:
- `vec::IntoIter` was already in the public API, but was previously unnameable.
- Exposing `Storage, VecInner` can be useful for users that want to write code or trait impls generic over the storage.
- Now that `Storage` is a sealed trait and the `Buffer` type is hidden, it's not leaking implementation details anymore. There's no `[MaybeUninit<T>]` in the public API, we can change it at any time without it being a breaking change.

I think we also should remove the `Vec, VecView` reexports in the crate root, but this is left for a future PR.

cc @sosthene-nitrokey
