### PR TITLE
 `MpMcQueue`: add `MpMcQueueView`, similar to `VecView` on top of #486

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Implemented `DoubleEndedIterator` for `OldestOrdered`.
 - Added std `Entry` methods to indexmap `Entry`.
 - Added `StringView`, the `!Sized` version of `String`.
+- Added `MpMcQueueView`, the `!Sized` version of `MpMcQueue`.
 
 ### Changed
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -4,6 +4,10 @@ use core::borrow::{Borrow, BorrowMut};
 
 pub(crate) trait SealedStorage {
     type Buffer<T>: ?Sized + Borrow<[T]> + BorrowMut<[T]>;
+    /// Obtain the length of the buffer
+    fn len<T>(this: *const Self::Buffer<T>) -> usize;
+    /// Obtain access to the first element of the buffer
+    fn as_ptr<T>(this: *mut Self::Buffer<T>) -> *mut T;
 }
 
 /// Trait defining how data for a container is stored.
@@ -33,6 +37,12 @@ pub enum OwnedStorage<const N: usize> {}
 impl<const N: usize> Storage for OwnedStorage<N> {}
 impl<const N: usize> SealedStorage for OwnedStorage<N> {
     type Buffer<T> = [T; N];
+    fn len<T>(_: *const Self::Buffer<T>) -> usize {
+        N
+    }
+    fn as_ptr<T>(this: *mut Self::Buffer<T>) -> *mut T {
+        this as _
+    }
 }
 
 /// Implementation of [`Storage`] that stores the data in an unsized `[T]`.
@@ -40,4 +50,17 @@ pub enum ViewStorage {}
 impl Storage for ViewStorage {}
 impl SealedStorage for ViewStorage {
     type Buffer<T> = [T];
+    fn len<T>(this: *const Self::Buffer<T>) -> usize {
+        // We get the len of the buffer. There is no reverse method of `core::ptr::from_raw_parts`, so we have to work around it.
+        let ptr: *const [()] = this as _;
+        // SAFETY: There is no aliasing as () is zero-sized
+        let slice: &[()] = unsafe { &*ptr };
+        let len = slice.len();
+
+        len - 1
+    }
+
+    fn as_ptr<T>(this: *mut Self::Buffer<T>) -> *mut T {
+        this as _
+    }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -53,13 +53,7 @@ impl Storage for ViewStorage {}
 impl SealedStorage for ViewStorage {
     type Buffer<T> = [T];
     fn len<T>(this: *const Self::Buffer<T>) -> usize {
-        // We get the len of the buffer. There is no reverse method of `core::ptr::from_raw_parts`, so we have to work around it.
-        let ptr: *const [()] = this as _;
-        // SAFETY: There is no aliasing as () is zero-sized
-        let slice: &[()] = unsafe { &*ptr };
-        let len = slice.len();
-
-        len - 1
+        this.len()
     }
 
     fn as_ptr<T>(this: *mut Self::Buffer<T>) -> *mut T {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -5,8 +5,10 @@ use core::borrow::{Borrow, BorrowMut};
 pub(crate) trait SealedStorage {
     type Buffer<T>: ?Sized + Borrow<[T]> + BorrowMut<[T]>;
     /// Obtain the length of the buffer
+    #[allow(unused)]
     fn len<T>(this: *const Self::Buffer<T>) -> usize;
     /// Obtain access to the first element of the buffer
+    #[allow(unused)]
     fn as_ptr<T>(this: *mut Self::Buffer<T>) -> *mut T;
 }
 


### PR DESCRIPTION
This would supersede #484. We need to pay attention to the `Drop` impl depending on the order we merge PRs

This adds a couple of methods to the `Storage` sealed trait to deal with the fact that `Borrow` cannot be used in concurrent code:

- One to safely get the length of the buffer from a pointer to it
- One to get a pointer to the beginning of the slice

