### PR TITLE
Implement DequeView on top of #486

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `MpMcQueueView`, the `!Sized` version of `MpMcQueue`.
 - Added `LinearMapView`, the `!Sized` version of `LinearMap`.
 - Added `HistoryBufferView`, the `!Sized` version of `HistoryBuffer`.
+- Added `DequeView`, the `!Sized` version of `Deque`.
 
 ### Changed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ pub use vec::{Vec, VecView};
 #[cfg(test)]
 mod test_helpers;
 
-mod deque;
+pub mod deque;
 pub mod histbuf;
 mod indexmap;
 mod indexset;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -2,12 +2,13 @@ use core::hash::{BuildHasher, Hash};
 
 use crate::{
     binary_heap::{BinaryHeapInner, Kind as BinaryHeapKind},
+    deque::DequeInner,
     histbuf::HistoryBufferInner,
     linear_map::LinearMapInner,
     storage::Storage,
     string::StringInner,
     vec::VecInner,
-    Deque, IndexMap, IndexSet,
+    IndexMap, IndexSet,
 };
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 
@@ -64,15 +65,15 @@ where
     }
 }
 
-impl<T, const N: usize> Serialize for Deque<T, N>
+impl<T, S: Storage> Serialize for DequeInner<T, S>
 where
     T: Serialize,
 {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    fn serialize<SER>(&self, serializer: SER) -> Result<SER::Ok, SER::Error>
     where
-        S: Serializer,
+        SER: Serializer,
     {
-        let mut seq = serializer.serialize_seq(Some(self.len()))?;
+        let mut seq = serializer.serialize_seq(Some(self.storage_len()))?;
         for element in self {
             seq.serialize_element(element)?;
         }


### PR DESCRIPTION
Efforts have been made to avoid breaking changes:

- Since `capacity` and `len` were `const`, they have been kept on `Deque`, and the generic version on `DequeInner` are prefixed by `storage` and are not `const`
- `Iter<'a, T, const N: usize>` is kept, and a new `IterView` type is added with conversions to and from both iter types. (I also simplified significantly the implementation of the `Iterator`, by using the standard library's iterator combinators).

By accepting a backward incompatible change, these APIs could be made more intuitive.