### PR TITLE
Implement HistoryBufferView on top of #486

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `StringView`, the `!Sized` version of `String`.
 - Added `MpMcQueueView`, the `!Sized` version of `MpMcQueue`.
 - Added `LinearMapView`, the `!Sized` version of `LinearMap`.
+- Added `HistoryBufferView`, the `!Sized` version of `HistoryBuffer`.
 
 ### Changed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ pub use vec::{Vec, VecView};
 mod test_helpers;
 
 mod deque;
-mod histbuf;
+pub mod histbuf;
 mod indexmap;
 mod indexset;
 pub mod linear_map;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,8 +1,8 @@
 use core::hash::{BuildHasher, Hash};
 
 use crate::{
-    binary_heap::Kind as BinaryHeapKind, linear_map::LinearMapInner, storage::Storage,
-    string::StringInner, vec::VecInner, BinaryHeap, Deque, HistoryBuffer, IndexMap, IndexSet,
+    binary_heap::Kind as BinaryHeapKind, histbuf::HistoryBufferInner, linear_map::LinearMapInner,
+    storage::Storage, string::StringInner, vec::VecInner, BinaryHeap, Deque, IndexMap, IndexSet,
 };
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 
@@ -74,13 +74,13 @@ where
     }
 }
 
-impl<T, const N: usize> Serialize for HistoryBuffer<T, N>
+impl<T, S: Storage> Serialize for HistoryBufferInner<T, S>
 where
     T: Serialize,
 {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    fn serialize<SER>(&self, serializer: SER) -> Result<SER::Ok, SER::Error>
     where
-        S: Serializer,
+        SER: Serializer,
     {
         let mut seq = serializer.serialize_seq(Some(self.len()))?;
         for element in self.oldest_ordered() {


### PR DESCRIPTION
`OldestOrdered` was already part of the public API.

When merging we will need to add its removal to #494 so that there is only `OldestOrederedView` (which can be renamed to just `OldestOrdered`)