### PR TITLE
 SortedLinkedList: add SortedLinkedListView, similar to VecView on top of #486

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `HistoryBufferView`, the `!Sized` version of `HistoryBuffer`.
 - Added `DequeView`, the `!Sized` version of `Deque`.
 - Added `QueueView`, the `!Sized` version of `Queue`.
+- Added `SortedLinkedListView`, the `!Sized` version of `SortedLinkedList`.
 
 ### Changed
 


### PR DESCRIPTION
Like the others, this will maintains backwards compatibility with:

- `Iter` and `FindMut` were public, so now they are made generic, but they should be made to always use the `View` version in a breaking release

TODO: Add this to #494 when merging