### PR TITLE
Impl Borrow and BorrowMut for String and Vec.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `DequeView`, the `!Sized` version of `Deque`.
 - Added `QueueView`, the `!Sized` version of `Queue`.
 - Added `SortedLinkedListView`, the `!Sized` version of `SortedLinkedList`.
+- Added implementation of `Borrow` and `BorrowMut` for `String` and `Vec`.
 
 ### Changed
 

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -71,7 +71,7 @@ where
     /// assert_eq!(map.capacity(), 8);
     /// ```
     pub fn capacity(&self) -> usize {
-        self.buffer.borrow().capacity()
+        self.buffer.capacity()
     }
 
     /// Clears the map, removing all key-value pairs.

--- a/src/string/mod.rs
+++ b/src/string/mod.rs
@@ -1,6 +1,7 @@
 //! A fixed capacity [`String`](https://doc.rust-lang.org/std/string/struct.String.html).
 
 use core::{
+    borrow,
     char::DecodeUtf16Error,
     cmp::Ordering,
     fmt,
@@ -728,6 +729,17 @@ impl<S: Storage> ops::Deref for StringInner<S> {
 
 impl<S: Storage> ops::DerefMut for StringInner<S> {
     fn deref_mut(&mut self) -> &mut str {
+        self.as_mut_str()
+    }
+}
+
+impl<S: Storage> borrow::Borrow<str> for StringInner<S> {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+impl<S: Storage> borrow::BorrowMut<str> for StringInner<S> {
+    fn borrow_mut(&mut self) -> &mut str {
         self.as_mut_str()
     }
 }

--- a/src/vec/mod.rs
+++ b/src/vec/mod.rs
@@ -1,5 +1,6 @@
 //! A fixed capacity [`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html).
 
+use core::borrow;
 use core::{
     borrow::{Borrow, BorrowMut},
     cmp::Ordering,
@@ -1406,6 +1407,17 @@ impl<T, S: Storage> ops::Deref for VecInner<T, S> {
 
 impl<T, S: Storage> ops::DerefMut for VecInner<T, S> {
     fn deref_mut(&mut self) -> &mut Self::Target {
+        self.as_mut_slice()
+    }
+}
+
+impl<T, S: Storage> borrow::Borrow<[T]> for VecInner<T, S> {
+    fn borrow(&self) -> &[T] {
+        self.as_slice()
+    }
+}
+impl<T, S: Storage> borrow::BorrowMut<[T]> for VecInner<T, S> {
+    fn borrow_mut(&mut self) -> &mut [T] {
         self.as_mut_slice()
     }
 }


### PR DESCRIPTION
This enables them to be used in maps, especially with &str get values in a Map<String, T>.

Closes #478 