### PR TITLE
Implement `Vec::drain`, `as_(mut_)view` on the `*Inner` types, generic over `Storage`

### DIFF
--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -184,14 +184,16 @@ impl<T, K, const N: usize> BinaryHeap<T, K, N> {
     pub fn into_vec(self) -> Vec<T, N> {
         self.data
     }
+}
 
+impl<T, K, S: VecStorage<T>> BinaryHeapInner<T, K, S> {
     /// Get a reference to the `BinaryHeap`, erasing the `N` const-generic.
     pub fn as_view(&self) -> &BinaryHeapView<T, K> {
-        self
+        S::as_binary_heap_view(self)
     }
     /// Get a mutable reference to the `BinaryHeap`, erasing the `N` const-generic.
     pub fn as_mut_view(&mut self) -> &mut BinaryHeapView<T, K> {
-        self
+        S::as_binary_heap_mut_view(self)
     }
 }
 

--- a/src/defmt.rs
+++ b/src/defmt.rs
@@ -1,7 +1,7 @@
 //! Defmt implementations for heapless types
 
 use crate::{
-    string::StringInner,
+    string::{StringInner, StringStorage},
     vec::{VecInner, VecStorage},
 };
 use defmt::Formatter;
@@ -15,7 +15,7 @@ where
     }
 }
 
-impl<S: VecStorage<u8> + ?Sized> defmt::Format for StringInner<S>
+impl<S: StringStorage + ?Sized> defmt::Format for StringInner<S>
 where
     u8: defmt::Format,
 {

--- a/src/deque.rs
+++ b/src/deque.rs
@@ -186,19 +186,19 @@ impl<T, const N: usize> Deque<T, N> {
             self.back - self.front
         }
     }
+}
 
+impl<T, S: VecStorage<T> + ?Sized> DequeInner<T, S> {
     /// Get a reference to the `Deque`, erasing the `N` const-generic.
     pub fn as_view(&self) -> &DequeView<T> {
-        self
+        S::as_deque_view(self)
     }
 
     /// Get a mutable reference to the `Deque`, erasing the `N` const-generic.
     pub fn as_mut_view(&mut self) -> &mut DequeView<T> {
-        self
+        S::as_deque_mut_view(self)
     }
-}
 
-impl<T, S: VecStorage<T> + ?Sized> DequeInner<T, S> {
     /// Returns the maximum number of elements the deque can hold.
     pub fn storage_capacity(&self) -> usize {
         self.buffer.borrow().len()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,6 +181,11 @@ pub mod storage;
 pub mod string;
 pub mod vec;
 
+// Workaround a compiler ICE in rust 1.83 to 1.86
+// https://github.com/rust-lang/rust/issues/138979#issuecomment-2760839948
+#[expect(dead_code)]
+fn dead_code_ice_workaround() {}
+
 #[cfg(feature = "serde")]
 mod de;
 #[cfg(feature = "serde")]

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -4,29 +4,103 @@
 
 use core::{borrow::Borrow, fmt, mem, ops, slice};
 
-use crate::vec::{OwnedVecStorage, Vec, VecStorage, ViewVecStorage};
+use crate::vec::{OwnedVecStorage, Vec, VecInner, ViewVecStorage};
 
-mod sealed {
-    use crate::vec::{VecInner, VecStorage};
-    /// Base struct for [`LinearMap`] and [`LinearMapView`]
-    pub struct LinearMapInnerInner<T, S: VecStorage<T> + ?Sized> {
-        pub(crate) buffer: VecInner<T, S>,
+mod storage {
+    use crate::vec::{OwnedVecStorage, VecStorage, ViewVecStorage};
+
+    use super::{LinearMapInner, LinearMapView};
+
+    /// Trait defining how data for a LinearMap is stored.
+    ///
+    /// There's two implementations available:
+    ///
+    /// - [`OwnedStorage`]: stores the data in an array whose size is known at compile time.
+    /// - [`ViewStorage`]: stores the data in an unsized slice
+    ///
+    /// This allows [`LinearMap`] to be generic over either sized or unsized storage. The [`linear_map`](super)
+    /// module contains a [`LinearMapInner`] struct that's generic on [`LinearMapStorage`],
+    /// and two type aliases for convenience:
+    ///
+    /// - [`LinearMap<N>`](crate::linear_map::LinearMap) = `LinearMapInner<OwnedStorage<u8, N>>`
+    /// - [`LinearMapView<T>`](crate::linear_map::LinearMapView) = `LinearMapInner<ViewStorage<u8>>`
+    ///
+    /// `LinearMap` can be unsized into `StrinsgView`, either by unsizing coercions such as `&mut LinearMap -> &mut LinearMapView` or
+    /// `Box<LinearMap> -> Box<LinearMapView>`, or explicitly with [`.as_view()`](crate::linear_map::LinearMap::as_view) or [`.as_mut_view()`](crate::linear_map::LinearMap::as_mut_view).
+    ///
+    /// This trait is sealed, so you cannot implement it for your own types. You can only use
+    /// the implementations provided by this crate.
+    ///
+    /// [`LinearMapInner`]: super::LinearMapInner
+    /// [`LinearMap`]: super::LinearMap
+    /// [`OwnedStorage`]: super::OwnedStorage
+    /// [`ViewStorage`]: super::ViewStorage
+    pub trait LinearMapStorage<K, V>: LinearMapStorageSealed<K, V> {}
+    pub trait LinearMapStorageSealed<K, V>: VecStorage<(K, V)> {
+        fn as_linear_map_view(this: &LinearMapInner<K, V, Self>) -> &LinearMapView<K, V>
+        where
+            Self: LinearMapStorage<K, V>;
+        fn as_linear_map_mut_view(
+            this: &mut LinearMapInner<K, V, Self>,
+        ) -> &mut LinearMapView<K, V>
+        where
+            Self: LinearMapStorage<K, V>;
+    }
+
+    impl<K, V, const N: usize> LinearMapStorage<K, V> for OwnedVecStorage<(K, V), N> {}
+    impl<K, V, const N: usize> LinearMapStorageSealed<K, V> for OwnedVecStorage<(K, V), N> {
+        fn as_linear_map_view(this: &LinearMapInner<K, V, Self>) -> &LinearMapView<K, V>
+        where
+            Self: LinearMapStorage<K, V>,
+        {
+            this
+        }
+        fn as_linear_map_mut_view(this: &mut LinearMapInner<K, V, Self>) -> &mut LinearMapView<K, V>
+        where
+            Self: LinearMapStorage<K, V>,
+        {
+            this
+        }
+    }
+
+    impl<K, V> LinearMapStorage<K, V> for ViewVecStorage<(K, V)> {}
+
+    impl<K, V> LinearMapStorageSealed<K, V> for ViewVecStorage<(K, V)> {
+        fn as_linear_map_view(this: &LinearMapInner<K, V, Self>) -> &LinearMapView<K, V>
+        where
+            Self: LinearMapStorage<K, V>,
+        {
+            this
+        }
+        fn as_linear_map_mut_view(this: &mut LinearMapInner<K, V, Self>) -> &mut LinearMapView<K, V>
+        where
+            Self: LinearMapStorage<K, V>,
+        {
+            this
+        }
     }
 }
-pub(crate) use sealed::LinearMapInnerInner;
+
+pub use storage::LinearMapStorage;
+/// Implementation of [`LinearMapStorage`] that stores the data in an array whose size is known at compile time.
+pub type OwnedStorage<K, V, const N: usize> = OwnedVecStorage<(K, V), N>;
+/// Implementation of [`LinearMapStorage`] that stores the data in an unsized slice.
+pub type ViewStorage<K, V> = ViewVecStorage<(K, V)>;
 
 /// Base struct for [`LinearMap`] and [`LinearMapView`]
-pub type LinearMapInner<K, V, S> = LinearMapInnerInner<(K, V), S>;
+pub struct LinearMapInner<K, V, S: LinearMapStorage<K, V> + ?Sized> {
+    pub(crate) buffer: VecInner<(K, V), S>,
+}
 
 /// A fixed capacity map/dictionary that performs lookups via linear search.
 ///
 /// Note that as this map doesn't use hashing so most operations are *O*(n) instead of *O*(1).
-pub type LinearMap<K, V, const N: usize> = LinearMapInner<K, V, OwnedVecStorage<(K, V), N>>;
+pub type LinearMap<K, V, const N: usize> = LinearMapInner<K, V, OwnedStorage<K, V, N>>;
 
 /// A dynamic capacity map/dictionary that performs lookups via linear search.
 ///
 /// Note that as this map doesn't use hashing so most operations are *O*(n) instead of *O*(1).
-pub type LinearMapView<K, V> = LinearMapInner<K, V, ViewVecStorage<(K, V)>>;
+pub type LinearMapView<K, V> = LinearMapInner<K, V, ViewStorage<K, V>>;
 
 impl<K, V, const N: usize> LinearMap<K, V, N> {
     /// Creates an empty `LinearMap`.
@@ -47,7 +121,7 @@ impl<K, V, const N: usize> LinearMap<K, V, N> {
     }
 }
 
-impl<K, V, S: VecStorage<(K, V)> + ?Sized> LinearMapInner<K, V, S>
+impl<K, V, S: LinearMapStorage<K, V> + ?Sized> LinearMapInner<K, V, S>
 where
     K: Eq,
 {
@@ -395,7 +469,7 @@ where
     }
 }
 
-impl<K, V, Q, S: VecStorage<(K, V)> + ?Sized> ops::Index<&'_ Q> for LinearMapInner<K, V, S>
+impl<K, V, Q, S: LinearMapStorage<K, V> + ?Sized> ops::Index<&'_ Q> for LinearMapInner<K, V, S>
 where
     K: Borrow<Q> + Eq,
     Q: Eq + ?Sized,
@@ -407,7 +481,7 @@ where
     }
 }
 
-impl<K, V, Q, S: VecStorage<(K, V)> + ?Sized> ops::IndexMut<&'_ Q> for LinearMapInner<K, V, S>
+impl<K, V, Q, S: LinearMapStorage<K, V> + ?Sized> ops::IndexMut<&'_ Q> for LinearMapInner<K, V, S>
 where
     K: Borrow<Q> + Eq,
     Q: Eq + ?Sized,
@@ -438,7 +512,7 @@ where
     }
 }
 
-impl<K, V, S: VecStorage<(K, V)> + ?Sized> fmt::Debug for LinearMapInner<K, V, S>
+impl<K, V, S: LinearMapStorage<K, V> + ?Sized> fmt::Debug for LinearMapInner<K, V, S>
 where
     K: Eq + fmt::Debug,
     V: fmt::Debug,
@@ -496,7 +570,7 @@ where
     }
 }
 
-impl<'a, K, V, S: VecStorage<(K, V)> + ?Sized> IntoIterator for &'a LinearMapInner<K, V, S>
+impl<'a, K, V, S: LinearMapStorage<K, V> + ?Sized> IntoIterator for &'a LinearMapInner<K, V, S>
 where
     K: Eq,
 {
@@ -540,7 +614,7 @@ impl<'a, K, V> Iterator for IterMut<'a, K, V> {
     }
 }
 
-impl<K, V, S1: VecStorage<(K, V)> + ?Sized, S2: VecStorage<(K, V)> + ?Sized>
+impl<K, V, S1: LinearMapStorage<K, V> + ?Sized, S2: LinearMapStorage<K, V> + ?Sized>
     PartialEq<LinearMapInner<K, V, S2>> for LinearMapInner<K, V, S1>
 where
     K: Eq,
@@ -554,7 +628,7 @@ where
     }
 }
 
-impl<K, V, S: VecStorage<(K, V)> + ?Sized> Eq for LinearMapInner<K, V, S>
+impl<K, V, S: LinearMapStorage<K, V> + ?Sized> Eq for LinearMapInner<K, V, S>
 where
     K: Eq,
     V: PartialEq,

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -11,7 +11,7 @@ mod storage {
 
     use super::{LinearMapInner, LinearMapView};
 
-    /// Trait defining how data for a LinearMap is stored.
+    /// Trait defining how data for a [`LinearMap`](super::LinearMap) is stored.
     ///
     /// There's two implementations available:
     ///

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -173,6 +173,18 @@ impl<T, const N: usize> MpMcQueue<T, N> {
             enqueue_pos: AtomicTargetSize::new(0),
         }
     }
+
+    /// Used in `Storage` implementation
+    pub(crate) fn as_view_private(&self) -> &MpMcQueueView<T> {
+        self
+    }
+    /// Used in `Storage` implementation
+    pub(crate) fn as_view_mut_private(&mut self) -> &mut MpMcQueueView<T> {
+        self
+    }
+}
+
+impl<T, S: Storage> MpMcQueueInner<T, S> {
     /// Get a reference to the `MpMcQueue`, erasing the `N` const-generic.
     ///
     ///
@@ -190,8 +202,8 @@ impl<T, const N: usize> MpMcQueue<T, N> {
     /// let view: &MpMcQueueView<u8> = &queue;
     /// ```
     #[inline]
-    pub const fn as_view(&self) -> &MpMcQueueView<T> {
-        self
+    pub fn as_view(&self) -> &MpMcQueueView<T> {
+        S::as_mpmc_view(self)
     }
 
     /// Get a mutable reference to the `MpMcQueue`, erasing the `N` const-generic.
@@ -211,11 +223,9 @@ impl<T, const N: usize> MpMcQueue<T, N> {
     /// ```
     #[inline]
     pub fn as_mut_view(&mut self) -> &mut MpMcQueueView<T> {
-        self
+        S::as_mpmc_mut_view(self)
     }
-}
 
-impl<T, S: Storage> MpMcQueueInner<T, S> {
     fn mask(&self) -> UintSize {
         (S::len(self.buffer.get()) - 1) as _
     }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -4,8 +4,8 @@ use crate::{
     binary_heap::{BinaryHeapInner, Kind as BinaryHeapKind},
     deque::DequeInner,
     histbuf::{HistBufStorage, HistoryBufferInner},
-    linear_map::LinearMapInner,
-    string::StringInner,
+    linear_map::{LinearMapInner, LinearMapStorage},
+    string::{StringInner, StringStorage},
     vec::{VecInner, VecStorage},
     IndexMap, IndexSet,
 };
@@ -116,7 +116,7 @@ where
     }
 }
 
-impl<K, V, S: VecStorage<(K, V)> + ?Sized> Serialize for LinearMapInner<K, V, S>
+impl<K, V, S: LinearMapStorage<K, V> + ?Sized> Serialize for LinearMapInner<K, V, S>
 where
     K: Eq + Serialize,
     V: Serialize,
@@ -135,7 +135,7 @@ where
 
 // String containers
 
-impl<S: VecStorage<u8> + ?Sized> Serialize for StringInner<S> {
+impl<S: StringStorage + ?Sized> Serialize for StringInner<S> {
     fn serialize<SER>(&self, serializer: SER) -> Result<SER::Ok, SER::Error>
     where
         SER: Serializer,

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -162,18 +162,28 @@ impl<T, const N: usize> Queue<T, N> {
         N - 1
     }
 
-    /// Get a reference to the `Queue`, erasing the `N` const-generic.
-    pub fn as_view(&self) -> &QueueView<T> {
+    /// Used in `Storage` implementation
+    pub(crate) fn as_view_private(&self) -> &QueueView<T> {
         self
     }
 
-    /// Get a mutable reference to the `Queue`, erasing the `N` const-generic.
-    pub fn as_mut_view(&mut self) -> &mut QueueView<T> {
+    /// Used in `Storage` implementation
+    pub(crate) fn as_mut_view_private(&mut self) -> &mut QueueView<T> {
         self
     }
 }
 
 impl<T, S: Storage> QueueInner<T, S> {
+    /// Get a reference to the `Queue`, erasing the `N` const-generic.
+    pub fn as_view(&self) -> &QueueView<T> {
+        S::as_queue_view(self)
+    }
+
+    /// Get a mutable reference to the `Queue`, erasing the `N` const-generic.
+    pub fn as_mut_view(&mut self) -> &mut QueueView<T> {
+        S::as_mut_queue_view(self)
+    }
+
     #[inline]
     fn increment(&self, val: usize) -> usize {
         (val + 1) % self.n()

--- a/src/ufmt.rs
+++ b/src/ufmt.rs
@@ -1,11 +1,11 @@
 use crate::{
-    string::StringInner,
+    string::{StringInner, StringStorage},
     vec::{VecInner, VecStorage},
     CapacityError,
 };
 use ufmt_write::uWrite;
 
-impl<S: VecStorage<u8> + ?Sized> uWrite for StringInner<S> {
+impl<S: StringStorage + ?Sized> uWrite for StringInner<S> {
     type Error = CapacityError;
     fn write_str(&mut self, s: &str) -> Result<(), Self::Error> {
         self.push_str(s)

--- a/src/vec/mod.rs
+++ b/src/vec/mod.rs
@@ -21,8 +21,6 @@ mod storage {
     use crate::{
         binary_heap::{BinaryHeapInner, BinaryHeapView},
         deque::{DequeInner, DequeView},
-        linear_map::LinearMapInnerInner,
-        string::StringInnerInner,
     };
 
     use super::{VecInner, VecView};
@@ -78,26 +76,6 @@ mod storage {
         where
             Self: VecStorage<T>;
         fn as_deque_mut_view(this: &mut DequeInner<T, Self>) -> &mut DequeView<T>
-        where
-            Self: VecStorage<T>;
-        fn as_linear_map_view(
-            this: &LinearMapInnerInner<T, Self>,
-        ) -> &LinearMapInnerInner<T, ViewVecStorage<T>>
-        where
-            Self: VecStorage<T>;
-        fn as_linear_map_mut_view(
-            this: &mut LinearMapInnerInner<T, Self>,
-        ) -> &mut LinearMapInnerInner<T, ViewVecStorage<T>>
-        where
-            Self: VecStorage<T>;
-        fn as_string_view(
-            this: &StringInnerInner<T, Self>,
-        ) -> &StringInnerInner<T, ViewVecStorage<T>>
-        where
-            Self: VecStorage<T>;
-        fn as_string_mut_view(
-            this: &mut StringInnerInner<T, Self>,
-        ) -> &mut StringInnerInner<T, ViewVecStorage<T>>
         where
             Self: VecStorage<T>;
     }
@@ -159,38 +137,6 @@ mod storage {
         {
             this
         }
-        fn as_linear_map_view(
-            this: &LinearMapInnerInner<T, Self>,
-        ) -> &LinearMapInnerInner<T, ViewVecStorage<T>>
-        where
-            Self: VecStorage<T>,
-        {
-            this
-        }
-        fn as_linear_map_mut_view(
-            this: &mut LinearMapInnerInner<T, Self>,
-        ) -> &mut LinearMapInnerInner<T, ViewVecStorage<T>>
-        where
-            Self: VecStorage<T>,
-        {
-            this
-        }
-        fn as_string_view(
-            this: &StringInnerInner<T, Self>,
-        ) -> &StringInnerInner<T, ViewVecStorage<T>>
-        where
-            Self: VecStorage<T>,
-        {
-            this
-        }
-        fn as_string_mut_view(
-            this: &mut StringInnerInner<T, Self>,
-        ) -> &mut StringInnerInner<T, ViewVecStorage<T>>
-        where
-            Self: VecStorage<T>,
-        {
-            this
-        }
     }
     impl<T, const N: usize> VecStorage<T> for OwnedVecStorage<T, N> {}
 
@@ -236,39 +182,6 @@ mod storage {
             this
         }
         fn as_deque_mut_view(this: &mut DequeInner<T, Self>) -> &mut DequeView<T>
-        where
-            Self: VecStorage<T>,
-        {
-            this
-        }
-        fn as_linear_map_view(
-            this: &LinearMapInnerInner<T, Self>,
-        ) -> &LinearMapInnerInner<T, ViewVecStorage<T>>
-        where
-            Self: VecStorage<T>,
-        {
-            this
-        }
-        fn as_linear_map_mut_view(
-            this: &mut LinearMapInnerInner<T, Self>,
-        ) -> &mut LinearMapInnerInner<T, ViewVecStorage<T>>
-        where
-            Self: VecStorage<T>,
-        {
-            this
-        }
-
-        fn as_string_view(
-            this: &StringInnerInner<T, Self>,
-        ) -> &StringInnerInner<T, ViewVecStorage<T>>
-        where
-            Self: VecStorage<T>,
-        {
-            this
-        }
-        fn as_string_mut_view(
-            this: &mut StringInnerInner<T, Self>,
-        ) -> &mut StringInnerInner<T, ViewVecStorage<T>>
         where
             Self: VecStorage<T>,
         {

--- a/src/vec/mod.rs
+++ b/src/vec/mod.rs
@@ -18,6 +18,15 @@ mod drain;
 mod storage {
     use core::mem::MaybeUninit;
 
+    use crate::{
+        binary_heap::{BinaryHeapInner, BinaryHeapView},
+        deque::{DequeInner, DequeView},
+        linear_map::LinearMapInnerInner,
+        string::StringInnerInner,
+    };
+
+    use super::{VecInner, VecView};
+
     /// Trait defining how data for a container is stored.
     ///
     /// There's two implementations available:
@@ -48,6 +57,49 @@ mod storage {
         // part of the sealed trait so that no trait is publicly implemented by `OwnedVecStorage` besides `Storage`
         fn borrow(&self) -> &[MaybeUninit<T>];
         fn borrow_mut(&mut self) -> &mut [MaybeUninit<T>];
+
+        fn as_vec_view(this: &VecInner<T, Self>) -> &VecView<T>
+        where
+            Self: VecStorage<T>;
+        fn as_vec_mut_view(this: &mut VecInner<T, Self>) -> &mut VecView<T>
+        where
+            Self: VecStorage<T>;
+
+        fn as_binary_heap_view<K>(this: &BinaryHeapInner<T, K, Self>) -> &BinaryHeapView<T, K>
+        where
+            Self: VecStorage<T>;
+        fn as_binary_heap_mut_view<K>(
+            this: &mut BinaryHeapInner<T, K, Self>,
+        ) -> &mut BinaryHeapView<T, K>
+        where
+            Self: VecStorage<T>;
+
+        fn as_deque_view(this: &DequeInner<T, Self>) -> &DequeView<T>
+        where
+            Self: VecStorage<T>;
+        fn as_deque_mut_view(this: &mut DequeInner<T, Self>) -> &mut DequeView<T>
+        where
+            Self: VecStorage<T>;
+        fn as_linear_map_view(
+            this: &LinearMapInnerInner<T, Self>,
+        ) -> &LinearMapInnerInner<T, ViewVecStorage<T>>
+        where
+            Self: VecStorage<T>;
+        fn as_linear_map_mut_view(
+            this: &mut LinearMapInnerInner<T, Self>,
+        ) -> &mut LinearMapInnerInner<T, ViewVecStorage<T>>
+        where
+            Self: VecStorage<T>;
+        fn as_string_view(
+            this: &StringInnerInner<T, Self>,
+        ) -> &StringInnerInner<T, ViewVecStorage<T>>
+        where
+            Self: VecStorage<T>;
+        fn as_string_mut_view(
+            this: &mut StringInnerInner<T, Self>,
+        ) -> &mut StringInnerInner<T, ViewVecStorage<T>>
+        where
+            Self: VecStorage<T>;
     }
 
     // One sealed layer of indirection to hide the internal details (The MaybeUninit).
@@ -67,6 +119,78 @@ mod storage {
         fn borrow_mut(&mut self) -> &mut [MaybeUninit<T>] {
             &mut self.buffer
         }
+
+        fn as_vec_view(this: &VecInner<T, Self>) -> &VecView<T>
+        where
+            Self: VecStorage<T>,
+        {
+            this
+        }
+        fn as_vec_mut_view(this: &mut VecInner<T, Self>) -> &mut VecView<T>
+        where
+            Self: VecStorage<T>,
+        {
+            this
+        }
+
+        fn as_binary_heap_view<K>(this: &BinaryHeapInner<T, K, Self>) -> &BinaryHeapView<T, K>
+        where
+            Self: VecStorage<T>,
+        {
+            this
+        }
+        fn as_binary_heap_mut_view<K>(
+            this: &mut BinaryHeapInner<T, K, Self>,
+        ) -> &mut BinaryHeapView<T, K>
+        where
+            Self: VecStorage<T>,
+        {
+            this
+        }
+        fn as_deque_view(this: &DequeInner<T, Self>) -> &DequeView<T>
+        where
+            Self: VecStorage<T>,
+        {
+            this
+        }
+        fn as_deque_mut_view(this: &mut DequeInner<T, Self>) -> &mut DequeView<T>
+        where
+            Self: VecStorage<T>,
+        {
+            this
+        }
+        fn as_linear_map_view(
+            this: &LinearMapInnerInner<T, Self>,
+        ) -> &LinearMapInnerInner<T, ViewVecStorage<T>>
+        where
+            Self: VecStorage<T>,
+        {
+            this
+        }
+        fn as_linear_map_mut_view(
+            this: &mut LinearMapInnerInner<T, Self>,
+        ) -> &mut LinearMapInnerInner<T, ViewVecStorage<T>>
+        where
+            Self: VecStorage<T>,
+        {
+            this
+        }
+        fn as_string_view(
+            this: &StringInnerInner<T, Self>,
+        ) -> &StringInnerInner<T, ViewVecStorage<T>>
+        where
+            Self: VecStorage<T>,
+        {
+            this
+        }
+        fn as_string_mut_view(
+            this: &mut StringInnerInner<T, Self>,
+        ) -> &mut StringInnerInner<T, ViewVecStorage<T>>
+        where
+            Self: VecStorage<T>,
+        {
+            this
+        }
     }
     impl<T, const N: usize> VecStorage<T> for OwnedVecStorage<T, N> {}
 
@@ -76,6 +200,79 @@ mod storage {
         }
         fn borrow_mut(&mut self) -> &mut [MaybeUninit<T>] {
             &mut self.buffer
+        }
+
+        fn as_vec_view(this: &VecInner<T, Self>) -> &VecView<T>
+        where
+            Self: VecStorage<T>,
+        {
+            this
+        }
+        fn as_vec_mut_view(this: &mut VecInner<T, Self>) -> &mut VecView<T>
+        where
+            Self: VecStorage<T>,
+        {
+            this
+        }
+
+        fn as_binary_heap_view<K>(this: &BinaryHeapInner<T, K, Self>) -> &BinaryHeapView<T, K>
+        where
+            Self: VecStorage<T>,
+        {
+            this
+        }
+        fn as_binary_heap_mut_view<K>(
+            this: &mut BinaryHeapInner<T, K, Self>,
+        ) -> &mut BinaryHeapView<T, K>
+        where
+            Self: VecStorage<T>,
+        {
+            this
+        }
+        fn as_deque_view(this: &DequeInner<T, Self>) -> &DequeView<T>
+        where
+            Self: VecStorage<T>,
+        {
+            this
+        }
+        fn as_deque_mut_view(this: &mut DequeInner<T, Self>) -> &mut DequeView<T>
+        where
+            Self: VecStorage<T>,
+        {
+            this
+        }
+        fn as_linear_map_view(
+            this: &LinearMapInnerInner<T, Self>,
+        ) -> &LinearMapInnerInner<T, ViewVecStorage<T>>
+        where
+            Self: VecStorage<T>,
+        {
+            this
+        }
+        fn as_linear_map_mut_view(
+            this: &mut LinearMapInnerInner<T, Self>,
+        ) -> &mut LinearMapInnerInner<T, ViewVecStorage<T>>
+        where
+            Self: VecStorage<T>,
+        {
+            this
+        }
+
+        fn as_string_view(
+            this: &StringInnerInner<T, Self>,
+        ) -> &StringInnerInner<T, ViewVecStorage<T>>
+        where
+            Self: VecStorage<T>,
+        {
+            this
+        }
+        fn as_string_mut_view(
+            this: &mut StringInnerInner<T, Self>,
+        ) -> &mut StringInnerInner<T, ViewVecStorage<T>>
+        where
+            Self: VecStorage<T>,
+        {
+            this
         }
     }
     impl<T> VecStorage<T> for ViewVecStorage<T> {}
@@ -283,47 +480,6 @@ impl<T, const N: usize> Vec<T, N> {
         new
     }
 
-    /// Get a reference to the `Vec`, erasing the `N` const-generic.
-    ///
-    ///
-    /// ```rust
-    /// # use heapless::{Vec, VecView};
-    /// let vec: Vec<u8, 10> = Vec::from_slice(&[1, 2, 3, 4]).unwrap();
-    /// let view: &VecView<u8> = vec.as_view();
-    /// ```
-    ///
-    /// It is often preferable to do the same through type coerction, since `Vec<T, N>` implements `Unsize<VecView<T>>`:
-    ///
-    /// ```rust
-    /// # use heapless::{Vec, VecView};
-    /// let vec: Vec<u8, 10> = Vec::from_slice(&[1, 2, 3, 4]).unwrap();
-    /// let view: &VecView<u8> = &vec;
-    /// ```
-    #[inline]
-    pub const fn as_view(&self) -> &VecView<T> {
-        self
-    }
-
-    /// Get a mutable reference to the `Vec`, erasing the `N` const-generic.
-    ///
-    /// ```rust
-    /// # use heapless::{Vec, VecView};
-    /// let mut vec: Vec<u8, 10> = Vec::from_slice(&[1, 2, 3, 4]).unwrap();
-    /// let view: &mut VecView<u8> = vec.as_mut_view();
-    /// ```
-    ///
-    /// It is often preferable to do the same through type coerction, since `Vec<T, N>` implements `Unsize<VecView<T>>`:
-    ///
-    /// ```rust
-    /// # use heapless::{Vec, VecView};
-    /// let mut vec: Vec<u8, 10> = Vec::from_slice(&[1, 2, 3, 4]).unwrap();
-    /// let view: &mut VecView<u8> = &mut vec;
-    /// ```
-    #[inline]
-    pub fn as_mut_view(&mut self) -> &mut VecView<T> {
-        self
-    }
-
     /// Removes the specified range from the vector in bulk, returning all
     /// removed elements as an iterator. If the iterator is dropped before
     /// being fully consumed, it drops the remaining removed elements.
@@ -430,6 +586,47 @@ impl<T> VecView<T> {
 }
 
 impl<T, S: VecStorage<T> + ?Sized> VecInner<T, S> {
+    /// Get a reference to the `Vec`, erasing the `N` const-generic.
+    ///
+    ///
+    /// ```rust
+    /// # use heapless::{Vec, VecView};
+    /// let vec: Vec<u8, 10> = Vec::from_slice(&[1, 2, 3, 4]).unwrap();
+    /// let view: &VecView<u8> = vec.as_view();
+    /// ```
+    ///
+    /// It is often preferable to do the same through type coerction, since `Vec<T, N>` implements `Unsize<VecView<T>>`:
+    ///
+    /// ```rust
+    /// # use heapless::{Vec, VecView};
+    /// let vec: Vec<u8, 10> = Vec::from_slice(&[1, 2, 3, 4]).unwrap();
+    /// let view: &VecView<u8> = &vec;
+    /// ```
+    #[inline]
+    pub fn as_view(&self) -> &VecView<T> {
+        S::as_vec_view(self)
+    }
+
+    /// Get a mutable reference to the `Vec`, erasing the `N` const-generic.
+    ///
+    /// ```rust
+    /// # use heapless::{Vec, VecView};
+    /// let mut vec: Vec<u8, 10> = Vec::from_slice(&[1, 2, 3, 4]).unwrap();
+    /// let view: &mut VecView<u8> = vec.as_mut_view();
+    /// ```
+    ///
+    /// It is often preferable to do the same through type coerction, since `Vec<T, N>` implements `Unsize<VecView<T>>`:
+    ///
+    /// ```rust
+    /// # use heapless::{Vec, VecView};
+    /// let mut vec: Vec<u8, 10> = Vec::from_slice(&[1, 2, 3, 4]).unwrap();
+    /// let view: &mut VecView<u8> = &mut vec;
+    /// ```
+    #[inline]
+    pub fn as_mut_view(&mut self) -> &mut VecView<T> {
+        S::as_vec_mut_view(self)
+    }
+
     /// Returns a raw pointer to the vector’s buffer.
     pub fn as_ptr(&self) -> *const T {
         self.buffer.borrow().as_ptr().cast::<T>()


### PR DESCRIPTION
This makes `drain` usable in the context of an implementation generic over the storage
This also makes it possible to get a `*View` in this same context

This could also be a way to "de-monomorphize" all the implementations of the `Inner` structs:

We could make all implementation define an inner function that is over a `View` type, and start the
implementation with `this = self.as_(mut_)view`, maybe for binary size and compilation time benefits. For example the implementation of `VecInner::push` could be:

```rust
    /// Appends an `item` to the back of the collection
    ///
    /// Returns back the `item` if the vector is full.
    pub fn push(&mut self, item: T) -> Result<(), T> {
        fn inner<T>(this: &mut VecView<T>, item: T) -> Result<(), T> {
            if this.len < this.storage_capacity() {
                unsafe { this.push_unchecked(item) }
                Ok(())
            } else {
                Err(item)
            }
        }
        inner(self.as_mut_view(), item)
    }
```