### PR TITLE
Relax indexmap PartialEq bounds so value doesn't need to be Eq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-- Relax bounds on `IndexMap` from `V: Eq` to `V: PartialEq`.
-
 ### Added
 
 - Added `format` macro.
@@ -60,6 +58,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Changed `stable_deref_trait` to a platform-dependent dependency.
 - Changed `SortedLinkedList::pop` return type from `Result<T, ()>` to `Option<T>` to match `std::vec::pop`.
 - `Vec::capacity` is no longer a `const` function.
+- Relaxed bounds on `PartialEq` for `IndexMap` from `V: Eq` to `V1: PartialEq<V2>`.
+- Relaxed bounds on `PartialEq` for `LinearMap` from `V: PartialEq` to `V1: PartialEq<V2>`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Relax `PartialEq` bounds on `IndexMap` from `V: Eq` to `V: PartialEq`.
+
 ### Added
 
 - Added `format` macro.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-- Relax `PartialEq` bounds on `IndexMap` from `V: Eq` to `V: PartialEq`.
+- Relax bounds on `IndexMap` from `V: Eq` to `V: PartialEq`.
 
 ### Added
 

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -1883,7 +1883,7 @@ mod tests {
     #[test]
     fn partial_eq_floats() {
         // Make sure PartialEq is implemented even if V doesn't implement Eq
-        let map: IndexMap<usize, f32> = Default::default();
+        let map: FnvIndexMap<usize, f32, 4> = Default::default();
         assert_eq!(map, map);
     }
 }

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -1879,4 +1879,11 @@ mod tests {
             assert_eq!(value, i + 1);
         }
     }
+
+    #[test]
+    fn partial_eq_floats() {
+        // Make sure PartialEq is implemented even if V doesn't implement Eq
+        let map: IndexMap<usize, f32> = Default::default();
+        assert_eq!(map, map);
+    }
 }

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -1280,7 +1280,7 @@ impl<K, V, S, S2, const N: usize, const N2: usize> PartialEq<IndexMap<K, V, S2, 
     for IndexMap<K, V, S, N>
 where
     K: Eq + Hash,
-    V: Eq,
+    V: PartialEq,
     S: BuildHasher,
     S2: BuildHasher,
 {

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -1276,15 +1276,15 @@ where
     }
 }
 
-impl<K, V, S, S2, const N: usize, const N2: usize> PartialEq<IndexMap<K, V, S2, N2>>
-    for IndexMap<K, V, S, N>
+impl<K, V1, V2, S1, S2, const N1: usize, const N2: usize> PartialEq<IndexMap<K, V2, S2, N2>>
+    for IndexMap<K, V1, S1, N1>
 where
     K: Eq + Hash,
-    V: PartialEq,
-    S: BuildHasher,
+    V1: PartialEq<V2>,
+    S1: BuildHasher,
     S2: BuildHasher,
 {
-    fn eq(&self, other: &IndexMap<K, V, S2, N2>) -> bool {
+    fn eq(&self, other: &IndexMap<K, V2, S2, N2>) -> bool {
         self.len() == other.len()
             && self
                 .iter()

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -1882,7 +1882,7 @@ mod tests {
 
     #[test]
     fn partial_eq_floats() {
-        // Make sure PartialEq is implemented even if V doesn't implement Eq
+        // Make sure `PartialEq` is implemented even if `V` doesn't implement `Eq`.
         let map: FnvIndexMap<usize, f32, 4> = Default::default();
         assert_eq!(map, map);
     }

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -614,13 +614,13 @@ impl<'a, K, V> Iterator for IterMut<'a, K, V> {
     }
 }
 
-impl<K, V, S1: LinearMapStorage<K, V> + ?Sized, S2: LinearMapStorage<K, V> + ?Sized>
-    PartialEq<LinearMapInner<K, V, S2>> for LinearMapInner<K, V, S1>
+impl<K, V1, V2, S1: LinearMapStorage<K, V1> + ?Sized, S2: LinearMapStorage<K, V2> + ?Sized>
+    PartialEq<LinearMapInner<K, V2, S2>> for LinearMapInner<K, V1, S1>
 where
     K: Eq,
-    V: PartialEq,
+    V1: PartialEq<V2>,
 {
-    fn eq(&self, other: &LinearMapInner<K, V, S2>) -> bool {
+    fn eq(&self, other: &LinearMapInner<K, V2, S2>) -> bool {
         self.len() == other.len()
             && self
                 .iter()
@@ -744,5 +744,12 @@ mod test {
         x: &'c LinearMapView<&'a (), u32>,
     ) -> &'c LinearMapView<&'b (), u32> {
         x
+    }
+
+    #[test]
+    fn partial_eq_floats() {
+        // Make sure `PartialEq` is implemented even if `V` doesn't implement `Eq`.
+        let map: LinearMap<usize, f32, 4> = Default::default();
+        assert_eq!(map, map);
     }
 }


### PR DESCRIPTION
The old bounds were unnecessarily strict. This PR relaxes the `V: Eq` bound to `V: PartialEq`. 