### PR TITLE
Implement a generic length parameter for Vec<T, N>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `truncate` to `IndexMap`.
 - Added `get_index` and `get_index_mut` to `IndexMap`.
 - Added `String::uDisplay`.
+- Added `LenT` generic to `Vec<T, N>` and `VecView<T>` to save memory when using a sane capacity value.
 
 ### Changed
 

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -57,7 +57,7 @@ impl private::Sealed for Min {}
 /// struct if you want to write code that's generic over both.
 pub struct BinaryHeapInner<T, K, S: VecStorage<T> + ?Sized> {
     pub(crate) _kind: PhantomData<K>,
-    pub(crate) data: VecInner<T, S>,
+    pub(crate) data: VecInner<T, usize, S>,
 }
 
 /// A priority queue implemented with a binary heap.
@@ -181,7 +181,7 @@ impl<T, K, const N: usize> BinaryHeap<T, K, N> {
 
 impl<T, K, const N: usize> BinaryHeap<T, K, N> {
     /// Returns the underlying `Vec<T,N>`. Order is arbitrary and time is *O*(1).
-    pub fn into_vec(self) -> Vec<T, N> {
+    pub fn into_vec(self) -> Vec<T, N, usize> {
         self.data
     }
 }

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,6 +1,6 @@
 use crate::{
-    binary_heap::Kind as BinaryHeapKind, BinaryHeap, Deque, HistoryBuffer, IndexMap, IndexSet,
-    LinearMap, String, Vec,
+    binary_heap::Kind as BinaryHeapKind, len_type::LenType, BinaryHeap, Deque, HistoryBuffer,
+    IndexMap, IndexSet, LinearMap, String, Vec,
 };
 use core::{
     fmt,
@@ -95,7 +95,7 @@ where
     }
 }
 
-impl<'de, T, const N: usize> Deserialize<'de> for Vec<T, N>
+impl<'de, T, LenT: LenType, const N: usize> Deserialize<'de> for Vec<T, N, LenT>
 where
     T: Deserialize<'de>,
 {
@@ -103,13 +103,14 @@ where
     where
         D: Deserializer<'de>,
     {
-        struct ValueVisitor<'de, T, const N: usize>(PhantomData<(&'de (), T)>);
+        struct ValueVisitor<'de, T, LenT: LenType, const N: usize>(PhantomData<(&'de (), T, LenT)>);
 
-        impl<'de, T, const N: usize> serde::de::Visitor<'de> for ValueVisitor<'de, T, N>
+        impl<'de, T, LenT, const N: usize> serde::de::Visitor<'de> for ValueVisitor<'de, T, LenT, N>
         where
             T: Deserialize<'de>,
+            LenT: LenType,
         {
-            type Value = Vec<T, N>;
+            type Value = Vec<T, N, LenT>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("a sequence")

--- a/src/defmt.rs
+++ b/src/defmt.rs
@@ -1,12 +1,13 @@
 //! Defmt implementations for heapless types
 
 use crate::{
+    len_type::LenType,
     string::{StringInner, StringStorage},
     vec::{VecInner, VecStorage},
 };
 use defmt::Formatter;
 
-impl<T, S: VecStorage<T> + ?Sized> defmt::Format for VecInner<T, S>
+impl<T, LenT: LenType, S: VecStorage<T> + ?Sized> defmt::Format for VecInner<T, LenT, S>
 where
     T: defmt::Format,
 {

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -138,7 +138,7 @@ macro_rules! probe_loop {
 }
 
 struct CoreMap<K, V, const N: usize> {
-    entries: Vec<Bucket<K, V>, N>,
+    entries: Vec<Bucket<K, V>, N, usize>,
     indices: [Option<Pos>; N],
 }
 
@@ -1417,7 +1417,7 @@ where
 
 #[derive(Clone)]
 pub struct IntoIter<K, V, const N: usize> {
-    entries: Vec<Bucket<K, V>, N>,
+    entries: Vec<Bucket<K, V>, N, usize>,
 }
 
 impl<K, V, const N: usize> Iterator for IntoIter<K, V, N> {

--- a/src/len_type.rs
+++ b/src/len_type.rs
@@ -3,34 +3,8 @@ use core::{
     ops::{Add, AddAssign, Sub, SubAssign},
 };
 
-mod private {
-    pub trait Sealed {}
-
-    impl Sealed for u8 {}
-    impl Sealed for u16 {}
-    #[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
-    impl Sealed for u32 {}
-
-    impl Sealed for usize {}
-}
-
-macro_rules! impl_lentype {
-    ($($(#[$meta:meta])* $LenT:ty),*) => {$(
-        $(#[$meta])*
-        impl LenType for $LenT {
-            const ZERO: Self = 0;
-            const ONE: Self = 1;
-            const MAX: usize = Self::MAX as _;
-        }
-    )*}
-}
-
-/// A sealed trait representing a valid type to use as a length for a container.
-///
-/// This cannot be implemented in user code, and is restricted to `u8`, `u16`, `u32`, and `usize`.
-pub trait LenType:
-    private::Sealed
-    + Send
+pub trait Sealed:
+    Send
     + Sync
     + Copy
     + Display
@@ -61,6 +35,25 @@ pub trait LenType:
         self.try_into().unwrap()
     }
 }
+
+macro_rules! impl_lentype {
+    ($($(#[$meta:meta])* $LenT:ty),*) => {$(
+        $(#[$meta])*
+        impl Sealed for $LenT {
+            const ZERO: Self = 0;
+            const ONE: Self = 1;
+            const MAX: usize = Self::MAX as _;
+        }
+
+        $(#[$meta])*
+        impl LenType for $LenT {}
+    )*}
+}
+
+/// A sealed trait representing a valid type to use as a length for a container.
+///
+/// This cannot be implemented in user code, and is restricted to `u8`, `u16`, `u32`, and `usize`.
+pub trait LenType: Sealed {}
 
 impl_lentype!(
     u8,

--- a/src/len_type.rs
+++ b/src/len_type.rs
@@ -26,11 +26,13 @@ pub trait Sealed:
     const MAX: usize;
 
     /// An infallible conversion from `usize` to `LenT`.
+    #[inline]
     fn from_usize(val: usize) -> Self {
         val.try_into().unwrap()
     }
 
     /// An infallible conversion from `LenT` to `usize`.
+    #[inline]
     fn into_usize(self) -> usize {
         self.try_into().unwrap()
     }

--- a/src/len_type.rs
+++ b/src/len_type.rs
@@ -1,0 +1,112 @@
+use core::{
+    fmt::{Debug, Display},
+    ops::{Add, AddAssign, Sub, SubAssign},
+};
+
+mod private {
+    pub trait Sealed {}
+
+    impl Sealed for u8 {}
+    impl Sealed for u16 {}
+    #[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
+    impl Sealed for u32 {}
+
+    impl Sealed for usize {}
+}
+
+macro_rules! impl_lentype {
+    ($($(#[$meta:meta])* $LenT:ty),*) => {$(
+        $(#[$meta])*
+        impl LenType for $LenT {
+            const ZERO: Self = 0;
+            const ONE: Self = 1;
+            const MAX: usize = Self::MAX as _;
+        }
+    )*}
+}
+
+/// A sealed trait representing a valid type to use as a length for a container.
+///
+/// This cannot be implemented in user code, and is restricted to `u8`, `u16`, `u32`, and `usize`.
+pub trait LenType:
+    private::Sealed
+    + Send
+    + Sync
+    + Copy
+    + Display
+    + Debug
+    + PartialEq
+    + Add<Output = Self>
+    + AddAssign
+    + Sub<Output = Self>
+    + SubAssign
+    + PartialOrd
+    + TryFrom<usize, Error: Debug>
+    + TryInto<usize, Error: Debug>
+{
+    /// The zero value of the integer type.
+    const ZERO: Self;
+    /// The one value of the integer type.
+    const ONE: Self;
+    /// The maximum value of this type, as a `usize`.
+    const MAX: usize;
+
+    /// An infallible conversion from `usize` to `LenT`.
+    fn from_usize(val: usize) -> Self {
+        val.try_into().unwrap()
+    }
+
+    /// An infallible conversion from `LenT` to `usize`.
+    fn into_usize(self) -> usize {
+        self.try_into().unwrap()
+    }
+}
+
+impl_lentype!(
+    u8,
+    u16,
+    #[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
+    u32,
+    usize
+);
+
+macro_rules! impl_lentodefault {
+    ($LenT:ty: $($len:literal),*) => {$(
+        impl SmallestLenType for Const<$len> {
+            type Type = $LenT;
+        }
+    )*};
+}
+
+/// A struct to create individual types for mapping with [`SmallestLenType`].
+///
+/// See the documentation of [`DefaultLenType`] for a detailed explanation.
+pub struct Const<const N: usize>;
+
+/// A trait to map [`Const`] to it's respective [`LenType`].
+///
+/// See the documentation of [`DefaultLenType`] for a detailed explanation.
+#[diagnostic::on_unimplemented(
+    message = "Length `N` does not have a default `LenType` mapping",
+    note = "Provide the `LenType` explicitly, such as `usize`"
+)]
+pub trait SmallestLenType {
+    type Type: LenType;
+}
+
+/// A type alias to perform the `const N: usize` -> `LenType` mapping.
+///
+/// This is impossible to perform directly, but it is possible to write a `const N: usize` -> related `Type` mapping via a const generic argument,
+/// then map from that to an unrelated type via a trait with associated types.
+///
+/// [`Const`] is the "related type" in the above explaination, [`SmallestLenType`] is the mapping trait.
+pub type DefaultLenType<const N: usize> = <Const<N> as SmallestLenType>::Type;
+
+impl_lentodefault!(u8: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255);
+impl_lentodefault!(u16: 256, 300, 400, 500, 512, 600, 700, 800, 900, 1000, 1024, 2000, 2048, 4000, 4096, 8000, 8192, 16000, 16384, 32000, 32768, 65000, 65535);
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
+impl_lentodefault!(u32: 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 33554432, 67108864, 134217728, 268435456, 536870912, 1073741824, 2147483648);
+
+pub const fn check_capacity_fits<LenT: LenType, const N: usize>() {
+    assert!(LenT::MAX >= N, "The capacity is larger than `LenT` can hold, increase the size of `LenT` or reduce the capacity");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,7 @@ pub use indexmap::{
     ValuesMut as IndexMapValuesMut,
 };
 pub use indexset::{FnvIndexSet, IndexSet, Iter as IndexSetIter};
+pub use len_type::LenType;
 pub use linear_map::LinearMap;
 pub use string::String;
 
@@ -178,6 +179,7 @@ pub mod deque;
 pub mod histbuf;
 mod indexmap;
 mod indexset;
+mod len_type;
 pub mod linear_map;
 mod slice;
 pub mod storage;

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -89,7 +89,7 @@ pub type ViewStorage<K, V> = ViewVecStorage<(K, V)>;
 
 /// Base struct for [`LinearMap`] and [`LinearMapView`]
 pub struct LinearMapInner<K, V, S: LinearMapStorage<K, V> + ?Sized> {
-    pub(crate) buffer: VecInner<(K, V), S>,
+    pub(crate) buffer: VecInner<(K, V), usize, S>,
 }
 
 /// A fixed capacity map/dictionary that performs lookups via linear search.
@@ -543,7 +543,7 @@ pub struct IntoIter<K, V, const N: usize>
 where
     K: Eq,
 {
-    inner: <Vec<(K, V), N> as IntoIterator>::IntoIter,
+    inner: <Vec<(K, V), N, usize> as IntoIterator>::IntoIter,
 }
 
 impl<K, V, const N: usize> Iterator for IntoIter<K, V, N>

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -4,6 +4,7 @@ use crate::{
     binary_heap::{BinaryHeapInner, Kind as BinaryHeapKind},
     deque::DequeInner,
     histbuf::{HistBufStorage, HistoryBufferInner},
+    len_type::LenType,
     linear_map::{LinearMapInner, LinearMapStorage},
     string::{StringInner, StringStorage},
     vec::{VecInner, VecStorage},
@@ -48,7 +49,7 @@ where
     }
 }
 
-impl<T, St: VecStorage<T> + ?Sized> Serialize for VecInner<T, St>
+impl<T, LenT: LenType, St: VecStorage<T>> Serialize for VecInner<T, LenT, St>
 where
     T: Serialize,
 {

--- a/src/ufmt.rs
+++ b/src/ufmt.rs
@@ -1,4 +1,5 @@
 use crate::{
+    len_type::LenType,
     string::{StringInner, StringStorage},
     vec::{VecInner, VecStorage},
     CapacityError,
@@ -24,7 +25,7 @@ impl<S: StringStorage + ?Sized> uWrite for StringInner<S> {
     }
 }
 
-impl<S: VecStorage<u8> + ?Sized> uWrite for VecInner<u8, S> {
+impl<LenT: LenType, S: VecStorage<u8> + ?Sized> uWrite for VecInner<u8, LenT, S> {
     type Error = CapacityError;
     #[inline]
     fn write_str(&mut self, s: &str) -> Result<(), Self::Error> {

--- a/src/vec/drain.rs
+++ b/src/vec/drain.rs
@@ -14,15 +14,6 @@ use super::VecView;
 ///
 /// This `struct` is created by [`Vec::drain`](super::Vec::drain).
 /// See its documentation for more.
-///
-/// # Example
-///
-/// ```
-/// use heapless::{vec, Vec};
-///
-/// let mut v = Vec::<_, 4>::from_array([0, 1, 2]);
-/// let iter: vec::Drain<'_, _, _> = v.drain(..);
-/// ```
 pub struct Drain<'a, T: 'a, LenT: LenType> {
     /// Index of tail to preserve
     pub(super) tail_start: LenT,

--- a/src/vec/drain.rs
+++ b/src/vec/drain.rs
@@ -6,6 +6,8 @@ use core::{
     slice,
 };
 
+use crate::len_type::LenType;
+
 use super::VecView;
 
 /// A draining iterator for [`Vec`](super::Vec).
@@ -19,25 +21,25 @@ use super::VecView;
 /// use heapless::{vec, Vec};
 ///
 /// let mut v = Vec::<_, 4>::from_array([0, 1, 2]);
-/// let iter: vec::Drain<'_, _> = v.drain(..);
+/// let iter: vec::Drain<'_, _, _> = v.drain(..);
 /// ```
-pub struct Drain<'a, T: 'a> {
+pub struct Drain<'a, T: 'a, LenT: LenType> {
     /// Index of tail to preserve
-    pub(super) tail_start: usize,
+    pub(super) tail_start: LenT,
     /// Length of tail
-    pub(super) tail_len: usize,
+    pub(super) tail_len: LenT,
     /// Current remaining range to remove
     pub(super) iter: slice::Iter<'a, T>,
-    pub(super) vec: NonNull<VecView<T>>,
+    pub(super) vec: NonNull<VecView<T, LenT>>,
 }
 
-impl<T: fmt::Debug> fmt::Debug for Drain<'_, T> {
+impl<T: fmt::Debug, LenT: LenType> fmt::Debug for Drain<'_, T, LenT> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Drain").field(&self.iter.as_slice()).finish()
     }
 }
 
-impl<T> Drain<'_, T> {
+impl<T, LenT: LenType> Drain<'_, T, LenT> {
     /// Returns the remaining items of this iterator as a slice.
     ///
     /// # Examples
@@ -57,16 +59,16 @@ impl<T> Drain<'_, T> {
     }
 }
 
-impl<T> AsRef<[T]> for Drain<'_, T> {
+impl<T, LenT: LenType> AsRef<[T]> for Drain<'_, T, LenT> {
     fn as_ref(&self) -> &[T] {
         self.as_slice()
     }
 }
 
-unsafe impl<T: Sync> Sync for Drain<'_, T> {}
-unsafe impl<T: Send> Send for Drain<'_, T> {}
+unsafe impl<T: Sync, LenT: LenType> Sync for Drain<'_, T, LenT> {}
+unsafe impl<T: Send, LenT: LenType> Send for Drain<'_, T, LenT> {}
 
-impl<T> Iterator for Drain<'_, T> {
+impl<T, LenT: LenType> Iterator for Drain<'_, T, LenT> {
     type Item = T;
 
     #[inline]
@@ -81,7 +83,7 @@ impl<T> Iterator for Drain<'_, T> {
     }
 }
 
-impl<T> DoubleEndedIterator for Drain<'_, T> {
+impl<T, LenT: LenType> DoubleEndedIterator for Drain<'_, T, LenT> {
     #[inline]
     fn next_back(&mut self) -> Option<T> {
         self.iter
@@ -90,25 +92,26 @@ impl<T> DoubleEndedIterator for Drain<'_, T> {
     }
 }
 
-impl<T> Drop for Drain<'_, T> {
+impl<T, LenT: LenType> Drop for Drain<'_, T, LenT> {
     fn drop(&mut self) {
         /// Moves back the un-`Drain`ed elements to restore the original `Vec`.
-        struct DropGuard<'r, 'a, T>(&'r mut Drain<'a, T>);
+        struct DropGuard<'r, 'a, T, LenT: LenType>(&'r mut Drain<'a, T, LenT>);
 
-        impl<T> Drop for DropGuard<'_, '_, T> {
+        impl<T, LenT: LenType> Drop for DropGuard<'_, '_, T, LenT> {
             fn drop(&mut self) {
-                if self.0.tail_len > 0 {
+                if self.0.tail_len > LenT::ZERO {
                     unsafe {
                         let source_vec = self.0.vec.as_mut();
                         // memmove back untouched tail, update to new length
                         let start = source_vec.len();
-                        let tail = self.0.tail_start;
+                        let tail = self.0.tail_start.into_usize();
+                        let tail_len = self.0.tail_len.into_usize();
                         if tail != start {
                             let dst = source_vec.as_mut_ptr().add(start);
                             let src = source_vec.as_ptr().add(tail);
-                            ptr::copy(src, dst, self.0.tail_len);
+                            ptr::copy(src, dst, tail_len);
                         }
-                        source_vec.set_len(start + self.0.tail_len);
+                        source_vec.set_len(start + tail_len);
                     }
                 }
             }
@@ -125,8 +128,9 @@ impl<T> Drop for Drain<'_, T> {
             unsafe {
                 let vec = vec.as_mut();
                 let old_len = vec.len();
-                vec.set_len(old_len + drop_len + self.tail_len);
-                vec.truncate(old_len + self.tail_len);
+                let tail_len = self.tail_len.into_usize();
+                vec.set_len(old_len + drop_len + tail_len);
+                vec.truncate(old_len + tail_len);
             }
 
             return;
@@ -159,9 +163,9 @@ impl<T> Drop for Drain<'_, T> {
     }
 }
 
-impl<T> ExactSizeIterator for Drain<'_, T> {}
+impl<T, LenT: LenType> ExactSizeIterator for Drain<'_, T, LenT> {}
 
-impl<T> FusedIterator for Drain<'_, T> {}
+impl<T, LenT: LenType> FusedIterator for Drain<'_, T, LenT> {}
 
 #[cfg(test)]
 mod tests {

--- a/src/vec/mod.rs
+++ b/src/vec/mod.rs
@@ -348,7 +348,7 @@ impl<T, LenT: LenType, const N: usize> Vec<T, N, LenT> {
         if N == M {
             Self {
                 phantom: PhantomData,
-                len: LenType::from_usize(N),
+                len: LenT::from_usize(N),
                 // NOTE(unsafe) ManuallyDrop<[T; M]> and [MaybeUninit<T>; N]
                 // have the same layout when N == M.
                 buffer: unsafe { mem::transmute_copy(&src) },


### PR DESCRIPTION
Currently, `Vec<T, N>` always uses `usize` for the length field, which leads to silly situations like `Vec<u8, 4>` being `8` bytes large on 32 bit platforms. This PR introduces a generic to provide this length field as well as a default for many common length values to avoid much user code changing.

I am okay to revert sections of this PR if wanted, such as
- ~~The change of `usize` to `LenT` in many arguments and return types, if they are considered too breaking.~~ Done, `usize` is still used for indexing and as the `len` return type.
- Adding the length generic to `VecView`, this can be changed to only store `usize` at the cost of only `Vec<T, N, usize>` being able to unsize (or requiring a `Vec::cast_len_type` call before unsizing, at least).

This lays the ground work for followup PRs to implement a similar length generic on the other containers, but I'm starting with just `Vec` to test the waters.