### PR TITLE
Rustdoc clippy and typo fixes

### DIFF
--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -1125,7 +1125,7 @@ where
     /// Remove the key-value pair equivalent to `key` and return its value.
     ///
     /// Like `Vec::swap_remove`, the pair is removed by swapping it with the last element of the map
-    /// and popping it off. **This perturbs the postion of what used to be the last element!**
+    /// and popping it off. **This perturbs the position of what used to be the last element!**
     ///
     /// Return `None` if `key` is not in map.
     ///

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -67,10 +67,10 @@
 //!   not.
 //! - All execution times are in clock cycles. 1 clock cycle = 125 ns.
 //! - Execution time is *dependent* of `mem::size_of::<T>()`. Both operations include one
-//! `memcpy(T)` in their successful path.
+//!   `memcpy(T)` in their successful path.
 //! - The optimization level is indicated in parentheses.
 //! - The numbers reported correspond to the successful path (i.e. `Some` is returned by `dequeue`
-//! and `Ok` is returned by `enqueue`).
+//!   and `Ok` is returned by `enqueue`).
 //!
 //! # Portability
 //!

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -151,8 +151,6 @@ pub type MpMcQueue<T, const N: usize> = MpMcQueueInner<T, OwnedStorage<N>>;
 pub type MpMcQueueView<T> = MpMcQueueInner<T, ViewStorage>;
 
 impl<T, const N: usize> MpMcQueue<T, N> {
-    const EMPTY_CELL: Cell<T> = Cell::new(0);
-
     const ASSERT: [(); 1] = [()];
 
     /// Creates an empty queue
@@ -167,7 +165,7 @@ impl<T, const N: usize> MpMcQueue<T, N> {
 
         let mut cell_count = 0;
 
-        let mut result_cells: [Cell<T>; N] = [Self::EMPTY_CELL; N];
+        let mut result_cells: [Cell<T>; N] = [const { Cell::new(0) }; N];
         while cell_count != N {
             result_cells[cell_count] = Cell::new(cell_count);
             cell_count += 1;

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -5,7 +5,7 @@
 //! This module/API is only available on these compilation targets:
 //!
 //! - ARM architectures which instruction set include the LDREX, CLREX and STREX instructions, e.g.
-//! `thumbv7m-none-eabi` but not `thumbv6m-none-eabi`
+//!   `thumbv7m-none-eabi` but not `thumbv6m-none-eabi`
 //! - 32-bit x86, e.g. `i686-unknown-linux-gnu`
 //!
 //! # Benchmarks
@@ -37,8 +37,8 @@
 //! ```
 //!
 //! - measurement method: the cycle counter (CYCCNT) register was sampled each time a breakpoint
-//! (`bkpt`) was hit. the difference between the "after" and the "before" value of CYCCNT yields the
-//! execution time in clock cycles.
+//!   (`bkpt`) was hit. the difference between the "after" and the "before" value of CYCCNT yields the
+//!   execution time in clock cycles.
 //!
 //! | API                          | clock cycles |
 //! |------------------------------|--------------|

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -92,10 +92,10 @@
 //!
 //! - All execution times are in clock cycles. 1 clock cycle = 125 ns.
 //! - Execution time is *dependent* of `mem::size_of::<T>()`. Both operations include one
-//! `memcpy(T)` in their successful path.
+//!   `memcpy(T)` in their successful path.
 //! - The optimization level is indicated in the first row.
 //! - The numbers reported correspond to the successful path (i.e. `Some` is returned by `dequeue`
-//! and `Ok` is returned by `enqueue`).
+//!   and `Ok` is returned by `enqueue`).
 
 use core::{borrow::Borrow, cell::UnsafeCell, fmt, hash, mem::MaybeUninit, ptr};
 

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -135,7 +135,6 @@ pub type Queue<T, const N: usize> = QueueInner<T, OwnedStorage<N>>;
 pub type QueueView<T> = QueueInner<T, ViewStorage>;
 
 impl<T, const N: usize> Queue<T, N> {
-    const INIT: UnsafeCell<MaybeUninit<T>> = UnsafeCell::new(MaybeUninit::uninit());
     /// Creates an empty queue with a fixed capacity of `N - 1`
     pub const fn new() -> Self {
         // Const assert N > 1
@@ -144,7 +143,7 @@ impl<T, const N: usize> Queue<T, N> {
         Queue {
             head: AtomicUsize::new(0),
             tail: AtomicUsize::new(0),
-            buffer: [Self::INIT; N],
+            buffer: [const { UnsafeCell::new(MaybeUninit::uninit()) }; N],
         }
     }
 

--- a/src/string/mod.rs
+++ b/src/string/mod.rs
@@ -1027,7 +1027,7 @@ mod tests {
         let s: String<4> = String::try_from("ab").unwrap();
         let b: Vec<u8, 4> = s.into_bytes();
         assert_eq!(b.len(), 2);
-        assert_eq!(&[b'a', b'b'], &b[..]);
+        assert_eq!(b"ab", &b[..]);
     }
 
     #[test]

--- a/src/string/mod.rs
+++ b/src/string/mod.rs
@@ -852,9 +852,9 @@ pub fn format<const N: usize>(args: Arguments<'_>) -> Result<String<N>, fmt::Err
 /// There are two possible error cases. Both return the unit type [`core::fmt::Error`].
 ///
 /// - In case the formatting exceeds the string's capacity. This error does not exist in
-/// the standard library as the string would just grow.
+///   the standard library as the string would just grow.
 /// - If a formatting trait implementation returns an error. The standard library panics
-/// in this case.
+///   in this case.
 ///
 /// # Examples
 ///
@@ -1102,7 +1102,7 @@ mod tests {
         match s.pop() {
             Some(c) => {
                 assert_eq!(s.len(), 1);
-                assert_eq!(c, '\u{0301}'); // accute accent of e
+                assert_eq!(c, '\u{0301}'); // acute accent of e
             }
             None => panic!(),
         };


### PR DESCRIPTION
Various documentation fixes for warnings shown by running `cargo clippy` and `typos`.