### PR TITLE
Implements PartialEq and Eq for Deque

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added implementation of `Borrow` and `BorrowMut` for `String` and `Vec`.
 - Added `Deque::{swap, swap_unchecked, swap_remove_front, swap_remove_back}`.
 - Make `String::from_utf8_unchecked` const.
+- Implemented `PartialEq` and `Eq` for `Deque`.
 
 ### Changed
 


### PR DESCRIPTION
Fixes #520.

This PR implements the `PartialEq` and `Eq` traits for `Deque`. The implementation of the `PartialEq` was copied from the implementation for the [collection's `VecDeque`](https://doc.rust-lang.org/src/alloc/collections/vec_deque/mod.rs.html#2776).
