### PR TITLE
Implemented TyrFrom for Deque from slice.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `SortedLinkedListView`, the `!Sized` version of `SortedLinkedList`.
 - Added implementation of `Borrow` and `BorrowMut` for `String` and `Vec`.
 - Added `Deque::{swap, swap_unchecked, swap_remove_front, swap_remove_back}`.
+- Implemented `TyrFrom` for `Deque` from slice.
 
 ### Changed
 

--- a/src/deque.rs
+++ b/src/deque.rs
@@ -1484,4 +1484,23 @@ mod tests {
         q.pop_front().unwrap();
         q.swap(0, 2);
     }
+
+    #[test]
+    fn tyr_from_slice() {
+
+        assert!(Deque::<u8, 3>::try_from([1, 2, 3, 4]).is_err());
+
+        let deq1 = Deque::<u8, 8>::try_from([1, 2, 3, 4]).unwrap();
+        let mut deq2 = Deque::<u8, 8>::new();
+        deq2.push_back(1).unwrap();
+        deq2.push_back(2).unwrap();
+        deq2.push_back(3).unwrap();
+        deq2.push_back(4).unwrap();
+
+        // todo change to `assert_eq!(deq1, deq2);` when PR #521 is merged.
+        assert_eq!(deq1.len(), deq2.len());
+        for (i, e1) in deq1.iter().enumerate() {
+          assert_eq!(Some(e1), deq2.get(i));
+        }
+    }
 }


### PR DESCRIPTION
Fixes #522.

Ideally, this PR is updated after PR #521 is merged to simplify the tests.

This PR implements the `TryFrom` trait for creating a `Deque` from a slice.

Note the use of `unsafe` for copying all bytes from the slice to the `Deque` buffer after ensuring that the `Deque` buffer has enough space.

Also note the use of `ManuallyDrop` to ensure that any heap memory referred to by the element contents is not dropped at the end of this method since the elements in the `Deque` buffer will be pointing to it.

