### PR TITLE
feat(indexmap): added `truncate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `Deque::{swap, swap_unchecked, swap_remove_front, swap_remove_back}`.
 - Make `String::from_utf8_unchecked` const.
 - Implemented `PartialEq` and `Eq` for `Deque`.
+- Added `truncate` to `IndexMap`.
 
 ### Changed
 

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -1169,9 +1169,9 @@ where
         self.core.retain_in_order(move |k, v| f(k, v));
     }
 
-    /// Shortens the map, keeping the first len elements and dropping the rest.
+    /// Shortens the map, keeping the first `len` elements and dropping the rest.
     ///
-    /// If len is greater than the map’s current length, this has no effect.
+    /// If `len` is greater than the map's current length, this has no effect.
     ///
     /// Computes in *O*(1) time (average).
     ///

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -1181,14 +1181,14 @@ where
     /// use heapless::FnvIndexMap;
     ///
     /// let mut map = FnvIndexMap::<_, _, 8>::new();
-    /// map.insert(1, "a").unwrap();
+    /// map.insert(3, "a").unwrap();
     /// map.insert(2, "b").unwrap();
-    /// map.insert(3, "c").unwrap();
+    /// map.insert(1, "c").unwrap();
     /// map.truncate(2);
     /// assert_eq!(map.len(), 2);
     ///
     /// let mut iter = map.iter();
-    /// assert_eq!(iter.next(), Some((&1, &"a")));
+    /// assert_eq!(iter.next(), Some((&3, &"a")));
     /// assert_eq!(iter.next(), Some((&2, &"b")));
     /// assert_eq!(iter.next(), None);
     /// ```

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -1169,6 +1169,33 @@ where
         self.core.retain_in_order(move |k, v| f(k, v));
     }
 
+    /// Shortens the map, keeping the first len elements and dropping the rest.
+    ///
+    /// If len is greater than the map’s current length, this has no effect.
+    ///
+    /// Computes in *O*(1) time (average).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use heapless::FnvIndexMap;
+    ///
+    /// let mut map = FnvIndexMap::<_, _, 8>::new();
+    /// map.insert(1, "a").unwrap();
+    /// map.insert(2, "b").unwrap();
+    /// map.insert(3, "c").unwrap();
+    /// map.truncate(2);
+    /// assert_eq!(map.len(), 2);
+    ///
+    /// let mut iter = map.iter();
+    /// assert_eq!(iter.next(), Some((&1, &"a")));
+    /// assert_eq!(iter.next(), Some((&2, &"b")));
+    /// assert_eq!(iter.next(), None);
+    /// ```
+    pub fn truncate(&mut self, len: usize) {
+        self.core.entries.truncate(len);
+    }
+
     /* Private API */
     /// Return probe (indices) and position (entries)
     fn find<Q>(&self, key: &Q) -> Option<(usize, usize)>


### PR DESCRIPTION
This adds `truncate` method to `IndexMap`.

See corresponding [truncate](https://docs.rs/indexmap/latest/indexmap/map/struct.IndexMap.html#method.truncate) in the [indexmap](https://docs.rs/indexmap/latest/indexmap/index.html) crate.

Related pull requests:
* #525 