### PR TITLE
Remove allow(clippy::result_unit_err)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Changed the error type of these methods from `()` to `CapacityError`.
+  - `String::push_str`
+  - `String::push`
+  - `Vec::extend_from_slice`
+  - `Vec::from_slice`
+  - `Vec::resize_default`
+  - `Vec::resize`
+- Renamed `FromUtf16Error::DecodeUtf16Error` to `FromUtf16Error::DecodeUtf16`.
 - Changed `stable_deref_trait` to a platform-dependent dependency.
 - Changed `SortedLinkedList::pop` return type from `Result<T, ()>` to `Option<T>` to match `std::vec::pop`.
 - `Vec::capacity` is no longer a `const` function.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,3 +233,16 @@ mod ufmt;
 pub mod _export {
     pub use crate::string::format;
 }
+
+/// The error type for fallible [`Vec`] and [`String`] methods.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct CapacityError;
+
+impl core::fmt::Display for CapacityError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("insufficient capacity")
+    }
+}
+
+impl core::error::Error for CapacityError {}

--- a/src/ufmt.rs
+++ b/src/ufmt.rs
@@ -1,18 +1,19 @@
 use crate::{
     string::StringInner,
     vec::{VecInner, VecStorage},
+    CapacityError,
 };
 use ufmt_write::uWrite;
 
 impl<S: VecStorage<u8> + ?Sized> uWrite for StringInner<S> {
-    type Error = ();
+    type Error = CapacityError;
     fn write_str(&mut self, s: &str) -> Result<(), Self::Error> {
         self.push_str(s)
     }
 }
 
 impl<S: VecStorage<u8> + ?Sized> uWrite for VecInner<u8, S> {
-    type Error = ();
+    type Error = CapacityError;
     fn write_str(&mut self, s: &str) -> Result<(), Self::Error> {
         self.extend_from_slice(s.as_bytes())
     }


### PR DESCRIPTION
Unit error types do not implement core::error::Error which leads to some ergonomic issues.