### PR TITLE
LinearMap: remove allow(clippy::map_identity)

### DIFF
--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -517,9 +517,6 @@ impl<'a, K, V> Iterator for Iter<'a, K, V> {
     type Item = (&'a K, &'a V);
 
     fn next(&mut self) -> Option<Self::Item> {
-        // False positive from clippy
-        // Option<&(K, V)> -> Option<(&K, &V)>
-        #[allow(clippy::map_identity)]
         self.iter.next().map(|(k, v)| (k, v))
     }
 }


### PR DESCRIPTION
This was previously required due to a false positive that has since been resolved.