### PR TITLE
`Vec`: rename `storage_capacity` to `capacity` and remove the `const` version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Changed `stable_deref_trait` to a platform-dependent dependency.
 - Changed `SortedLinkedList::pop` return type from `Result<T, ()>` to `Option<T>` to match `std::vec::pop`.
+- `Vec::capacity` is no longer a `const` function.
 
 ### Fixed
 
@@ -55,6 +56,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   `HistoryBuffer` and `SortedLinkedList` to the list.
 - Fixed `MpMcQueue` with `mpmc_large` feature.
 - Fix missing `Drop` for `MpMcQueue`
+
+### Removed
+
+- `Vec::storage_capacity` has been removed and `Vec::capacity` must be used instead.
 
 ## [v0.8.0] - 2023-11-07
 

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -203,7 +203,7 @@ where
     /* Public API */
     /// Returns the capacity of the binary heap.
     pub fn capacity(&self) -> usize {
-        self.data.storage_capacity()
+        self.data.capacity()
     }
 
     /// Drops all items from the binary heap.

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -67,7 +67,7 @@ where
     /// assert_eq!(map.capacity(), 8);
     /// ```
     pub fn capacity(&self) -> usize {
-        self.buffer.storage_capacity()
+        self.buffer.capacity()
     }
 
     /// Clears the map, removing all key-value pairs.

--- a/src/string/mod.rs
+++ b/src/string/mod.rs
@@ -455,7 +455,7 @@ impl<S: VecStorage<u8> + ?Sized> StringInner<S> {
     /// ```
     #[inline]
     pub fn capacity(&self) -> usize {
-        self.vec.storage_capacity()
+        self.vec.capacity()
     }
 
     /// Appends the given [`char`] to the end of this `String`.

--- a/src/vec/mod.rs
+++ b/src/vec/mod.rs
@@ -362,13 +362,6 @@ impl<T, const N: usize> Vec<T, N> {
     {
         self.as_mut_view().drain(range)
     }
-
-    /// Returns the maximum number of elements the vector can hold.
-    ///
-    /// This method is not available on a `VecView`, use [`storage_len`](VecInner::storage_capacity) instead
-    pub const fn capacity(&self) -> usize {
-        self.buffer.buffer.len()
-    }
 }
 
 impl<T> VecView<T> {
@@ -486,7 +479,7 @@ impl<T, S: VecStorage<T> + ?Sized> VecInner<T, S> {
     }
 
     /// Returns the maximum number of elements the vector can hold.
-    pub fn storage_capacity(&self) -> usize {
+    pub fn capacity(&self) -> usize {
         self.buffer.borrow().len()
     }
 
@@ -565,7 +558,7 @@ impl<T, S: VecStorage<T> + ?Sized> VecInner<T, S> {
     ///
     /// Returns back the `item` if the vector is full.
     pub fn push(&mut self, item: T) -> Result<(), T> {
-        if self.len < self.storage_capacity() {
+        if self.len < self.capacity() {
             unsafe { self.push_unchecked(item) }
             Ok(())
         } else {
@@ -639,7 +632,7 @@ impl<T, S: VecStorage<T> + ?Sized> VecInner<T, S> {
     where
         T: Clone,
     {
-        if new_len > self.storage_capacity() {
+        if new_len > self.capacity() {
             return Err(());
         }
 
@@ -759,7 +752,7 @@ impl<T, S: VecStorage<T> + ?Sized> VecInner<T, S> {
     /// Normally, here, one would use [`clear`] instead to correctly drop
     /// the contents and thus not leak memory.
     pub unsafe fn set_len(&mut self, new_len: usize) {
-        debug_assert!(new_len <= self.storage_capacity());
+        debug_assert!(new_len <= self.capacity());
 
         self.len = new_len
     }
@@ -835,7 +828,7 @@ impl<T, S: VecStorage<T> + ?Sized> VecInner<T, S> {
 
     /// Returns true if the vec is full
     pub fn is_full(&self) -> bool {
-        self.len == self.storage_capacity()
+        self.len == self.capacity()
     }
 
     /// Returns true if the vec is empty


### PR DESCRIPTION
See https://github.com/rust-embedded/heapless/issues/494
