### PR TITLE
Remove `#[allow(clippy::result_unit_err)]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Changed `stable_deref_trait` to a platform-dependent dependency.
 - Changed `SortedLinkedList::pop` return type from `Result<T, ()>` to `Option<T>` to match `std::vec::pop`.
 - `Vec::capacity` is no longer a `const` function.
+- Changed `String::push_str` return type to `Option<()>`.
+- Changed `String::push` return type to `Option<()>`.
+- Changed `Vec::from_slice` return type to `Option<Self>`.
+- Changed `Vec::extend_from_slice` return type to `Option<()>`.
+- Changed `Vec::resize` return type to `Option<()>`.
+- Changed `Vec::resize_defualt` return type to `Option<()>`.
+- Changed `SortedLinkedList::rpop` return type to `Option<T>`.
 
 ### Fixed
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -318,7 +318,7 @@ impl<'de, const N: usize> Deserialize<'de> for String<N> {
             {
                 let mut s = String::new();
                 s.push_str(v)
-                    .map_err(|_| E::invalid_length(v.len(), &self))?;
+                    .ok_or_else(|| E::invalid_length(v.len(), &self))?;
                 Ok(s)
             }
 
@@ -332,7 +332,7 @@ impl<'de, const N: usize> Deserialize<'de> for String<N> {
                     core::str::from_utf8(v)
                         .map_err(|_| E::invalid_value(de::Unexpected::Bytes(v), &self))?,
                 )
-                .map_err(|_| E::invalid_length(v.len(), &self))?;
+                .ok_or_else(|| E::invalid_length(v.len(), &self))?;
 
                 Ok(s)
             }

--- a/src/ufmt.rs
+++ b/src/ufmt.rs
@@ -7,14 +7,14 @@ use ufmt_write::uWrite;
 impl<S: VecStorage<u8> + ?Sized> uWrite for StringInner<S> {
     type Error = ();
     fn write_str(&mut self, s: &str) -> Result<(), Self::Error> {
-        self.push_str(s)
+        self.push_str(s).ok_or_else(|| ())
     }
 }
 
 impl<S: VecStorage<u8> + ?Sized> uWrite for VecInner<u8, S> {
     type Error = ();
     fn write_str(&mut self, s: &str) -> Result<(), Self::Error> {
-        self.extend_from_slice(s.as_bytes())
+        self.extend_from_slice(s.as_bytes()).ok_or_else(|| ())
     }
 }
 


### PR DESCRIPTION
- **Remove unit errors from `String` and `Vec`**
- **Remove unit errors from `SortedLinkedList`**
- **Update changelog**

Fixes #533

There is an unsolved question regarding trait implementations with associated error types like `TryFrom` where in some cases `TryFrom::Err` is still `()`. In that case, we still have the issue of `()` not implementing `Error` but the only way to fix it would be to introduce a new error type on each case. Is that acceptable?