### PR TITLE
Fix `clippy::nursery` warnings

### DIFF
--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -596,14 +596,14 @@ where
     }
 }
 
-impl<'a, T, K, S> PeekMutInner<'a, T, K, S>
+impl<T, K, S> PeekMutInner<'_, T, K, S>
 where
     T: Ord,
     K: Kind,
     S: VecStorage<T> + ?Sized,
 {
     /// Removes the peeked value from the heap and returns it.
-    pub fn pop(mut this: PeekMutInner<'a, T, K, S>) -> T {
+    pub fn pop(mut this: Self) -> T {
         let value = this.heap.pop().unwrap();
         this.sift = false;
         value

--- a/src/deque.rs
+++ b/src/deque.rs
@@ -946,7 +946,7 @@ where
     T: Clone,
 {
     fn clone(&self) -> Self {
-        let mut res = Deque::new();
+        let mut res = Self::new();
         for i in self {
             // safety: the original and new deques have the same capacity, so it can
             // not become full.

--- a/src/histbuf.rs
+++ b/src/histbuf.rs
@@ -587,7 +587,8 @@ pub struct OldestOrderedInner<'a, T, S: HistBufStorage<T> + ?Sized> {
 }
 
 /// Double ended iterator on the underlying buffer ordered from the oldest data
-/// to the newest
+/// to the newest.
+///
 /// This type exists for backwards compatibility. It is always better to convert it to an [`OldestOrderedView`] with [`into_view`](OldestOrdered::into_view)
 pub type OldestOrdered<'a, T, const N: usize> =
     OldestOrderedInner<'a, T, OwnedHistBufStorage<T, N>>;

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -97,7 +97,7 @@ pub struct Pos {
 
 impl Pos {
     fn new(index: usize, hash: HashValue) -> Self {
-        Pos {
+        Self {
             nz: unsafe {
                 NonZeroU32::new_unchecked(
                     ((u32::from(hash.0) << 16) + index as u32).wrapping_add(1),
@@ -146,7 +146,7 @@ impl<K, V, const N: usize> CoreMap<K, V, N> {
     const fn new() -> Self {
         const INIT: Option<Pos> = None;
 
-        CoreMap {
+        Self {
             entries: Vec::new(),
             indices: [INIT; N],
         }
@@ -733,7 +733,7 @@ impl<K, V, S, const N: usize> IndexMap<K, V, BuildHasherDefault<S>, N> {
         crate::sealed::greater_than_1::<N>();
         crate::sealed::power_of_two::<N>();
 
-        IndexMap {
+        Self {
             build_hasher: BuildHasherDefault::new(),
             core: CoreMap::new(),
         }
@@ -1240,7 +1240,7 @@ where
         crate::sealed::greater_than_1::<N>();
         crate::sealed::power_of_two::<N>();
 
-        IndexMap {
+        Self {
             build_hasher: <_>::default(),
             core: CoreMap::new(),
         }
@@ -1309,7 +1309,7 @@ where
     where
         I: IntoIterator<Item = (K, V)>,
     {
-        let mut map = IndexMap::default();
+        let mut map = Self::default();
         map.extend(iterable);
         map
     }

--- a/src/indexset.rs
+++ b/src/indexset.rs
@@ -91,7 +91,7 @@ pub struct IndexSet<T, S, const N: usize> {
 impl<T, S, const N: usize> IndexSet<T, BuildHasherDefault<S>, N> {
     /// Creates an empty `IndexSet`
     pub const fn new() -> Self {
-        IndexSet {
+        Self {
             map: IndexMap::new(),
         }
     }
@@ -533,7 +533,7 @@ where
     S: Default,
 {
     fn default() -> Self {
-        IndexSet {
+        Self {
             map: <_>::default(),
         }
     }
@@ -586,7 +586,7 @@ where
     where
         I: IntoIterator<Item = T>,
     {
-        let mut set = IndexSet::default();
+        let mut set = Self::default();
         set.extend(iter);
         set
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,7 @@
     ),
     feature(integer_atomics)
 )]
+#![warn(clippy::use_self)]
 
 pub use binary_heap::BinaryHeap;
 pub use deque::Deque;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,8 @@
 #![warn(
     clippy::use_self,
     clippy::too_long_first_doc_paragraph,
-    clippy::redundant_pub_crate
+    clippy::redundant_pub_crate,
+    clippy::option_if_let_else
 )]
 
 pub use binary_heap::BinaryHeap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@
     ),
     feature(integer_atomics)
 )]
-#![warn(clippy::use_self)]
+#![warn(clippy::use_self, clippy::too_long_first_doc_paragraph)]
 
 pub use binary_heap::BinaryHeap;
 pub use deque::Deque;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,11 @@
     ),
     feature(integer_atomics)
 )]
-#![warn(clippy::use_self, clippy::too_long_first_doc_paragraph)]
+#![warn(
+    clippy::use_self,
+    clippy::too_long_first_doc_paragraph,
+    clippy::redundant_pub_crate
+)]
 
 pub use binary_heap::BinaryHeap;
 pub use deque::Deque;

--- a/src/pool/treiber/cas.rs
+++ b/src/pool/treiber/cas.rs
@@ -120,7 +120,7 @@ where
     }
 
     #[inline]
-    pub fn from_static_mut_ref(reference: &'static mut N) -> NonNullPtr<N> {
+    pub fn from_static_mut_ref(reference: &'static mut N) -> Self {
         // SAFETY: `reference` is a static mutable reference, i.e. a valid pointer.
         unsafe { Self::new_unchecked(initial_tag(), NonNull::from(reference)) }
     }

--- a/src/sealed.rs
+++ b/src/sealed.rs
@@ -1,30 +1,30 @@
 #[allow(dead_code, path_statements, clippy::no_effect)]
-pub(crate) const fn smaller_than<const N: usize, const MAX: usize>() {
+pub const fn smaller_than<const N: usize, const MAX: usize>() {
     Assert::<N, MAX>::LESS;
 }
 
 #[allow(dead_code, path_statements, clippy::no_effect)]
-pub(crate) const fn greater_than_eq<const N: usize, const MIN: usize>() {
+pub const fn greater_than_eq<const N: usize, const MIN: usize>() {
     Assert::<N, MIN>::GREATER_EQ;
 }
 
 #[allow(dead_code, path_statements, clippy::no_effect)]
-pub(crate) const fn greater_than_eq_0<const N: usize>() {
+pub const fn greater_than_eq_0<const N: usize>() {
     Assert::<N, 0>::GREATER_EQ;
 }
 
 #[allow(dead_code, path_statements, clippy::no_effect)]
-pub(crate) const fn greater_than_0<const N: usize>() {
+pub const fn greater_than_0<const N: usize>() {
     Assert::<N, 0>::GREATER;
 }
 
 #[allow(dead_code, path_statements, clippy::no_effect)]
-pub(crate) const fn greater_than_1<const N: usize>() {
+pub const fn greater_than_1<const N: usize>() {
     Assert::<N, 1>::GREATER;
 }
 
 #[allow(dead_code, path_statements, clippy::no_effect)]
-pub(crate) const fn power_of_two<const N: usize>() {
+pub const fn power_of_two<const N: usize>() {
     Assert::<N, 0>::GREATER;
     Assert::<N, 0>::POWER_OF_TWO;
 }

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -368,7 +368,7 @@ where
     T: Clone,
 {
     fn clone(&self) -> Self {
-        let mut new: Queue<T, N> = Queue::new();
+        let mut new: Self = Self::new();
 
         for s in self.iter() {
             unsafe {
@@ -829,7 +829,7 @@ mod tests {
                 unsafe {
                     COUNT += 1;
                 }
-                Droppable
+                Self
             }
         }
 

--- a/src/string/mod.rs
+++ b/src/string/mod.rs
@@ -581,10 +581,10 @@ impl<S: VecStorage<u8> + ?Sized> StringInner<S> {
     /// ```
     #[inline]
     pub fn remove(&mut self, index: usize) -> char {
-        let ch = match self[index..].chars().next() {
-            Some(ch) => ch,
-            None => panic!("cannot remove a char from the end of a string"),
-        };
+        let ch = self[index..]
+            .chars()
+            .next()
+            .unwrap_or_else(|| panic!("cannot remove a char from the end of a string"));
 
         let next = index + ch.len_utf8();
         let len = self.len();

--- a/src/string/mod.rs
+++ b/src/string/mod.rs
@@ -632,7 +632,7 @@ impl<const N: usize> Default for String<N> {
 impl<'a, const N: usize> TryFrom<&'a str> for String<N> {
     type Error = ();
     fn try_from(s: &'a str) -> Result<Self, Self::Error> {
-        let mut new = String::new();
+        let mut new = Self::new();
         new.push_str(s)?;
         Ok(new)
     }
@@ -642,7 +642,7 @@ impl<const N: usize> str::FromStr for String<N> {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut new = String::new();
+        let mut new = Self::new();
         new.push_str(s)?;
         Ok(new)
     }
@@ -650,7 +650,7 @@ impl<const N: usize> str::FromStr for String<N> {
 
 impl<const N: usize> iter::FromIterator<char> for String<N> {
     fn from_iter<T: IntoIterator<Item = char>>(iter: T) -> Self {
-        let mut new = String::new();
+        let mut new = Self::new();
         for c in iter {
             new.push(c).unwrap();
         }
@@ -660,7 +660,7 @@ impl<const N: usize> iter::FromIterator<char> for String<N> {
 
 impl<'a, const N: usize> iter::FromIterator<&'a char> for String<N> {
     fn from_iter<T: IntoIterator<Item = &'a char>>(iter: T) -> Self {
-        let mut new = String::new();
+        let mut new = Self::new();
         for c in iter {
             new.push(*c).unwrap();
         }
@@ -670,7 +670,7 @@ impl<'a, const N: usize> iter::FromIterator<&'a char> for String<N> {
 
 impl<'a, const N: usize> iter::FromIterator<&'a str> for String<N> {
     fn from_iter<T: IntoIterator<Item = &'a str>>(iter: T) -> Self {
-        let mut new = String::new();
+        let mut new = Self::new();
         for c in iter {
             new.push_str(c).unwrap();
         }
@@ -782,7 +782,7 @@ impl<S: VecStorage<u8> + ?Sized> PartialEq<&str> for StringInner<S> {
 impl<S: VecStorage<u8> + ?Sized> PartialEq<StringInner<S>> for str {
     #[inline]
     fn eq(&self, other: &StringInner<S>) -> bool {
-        str::eq(self, &other[..])
+        Self::eq(self, &other[..])
     }
 }
 

--- a/src/vec/mod.rs
+++ b/src/vec/mod.rs
@@ -197,7 +197,7 @@ impl<T, const N: usize> Vec<T, N> {
     where
         T: Clone,
     {
-        let mut v = Vec::new();
+        let mut v = Self::new();
         v.extend_from_slice(other)?;
         Ok(v)
     }
@@ -229,7 +229,7 @@ impl<T, const N: usize> Vec<T, N> {
                 buffer: unsafe { mem::transmute_copy(&src) },
             }
         } else {
-            let mut v = Vec::<T, N>::new();
+            let mut v = Self::new();
 
             for (src_elem, dst_elem) in src.iter().zip(v.buffer.buffer.iter_mut()) {
                 // NOTE(unsafe) src element is not going to drop as src itself
@@ -1222,7 +1222,7 @@ impl<'a, T: Clone, const N: usize> TryFrom<&'a [T]> for Vec<T, N> {
     type Error = ();
 
     fn try_from(slice: &'a [T]) -> Result<Self, Self::Error> {
-        Vec::from_slice(slice)
+        Self::from_slice(slice)
     }
 }
 
@@ -1279,7 +1279,7 @@ impl<T, const N: usize> FromIterator<T> for Vec<T, N> {
     where
         I: IntoIterator<Item = T>,
     {
-        let mut vec = Vec::new();
+        let mut vec = Self::new();
         for i in iter {
             vec.push(i).ok().expect("Vec::from_iter overflow");
         }
@@ -1509,14 +1509,14 @@ impl<T, S: VecStorage<T> + ?Sized> borrow::BorrowMut<[T]> for VecInner<T, S> {
     }
 }
 
-impl<T, S: VecStorage<T> + ?Sized> AsRef<VecInner<T, S>> for VecInner<T, S> {
+impl<T, S: VecStorage<T> + ?Sized> AsRef<Self> for VecInner<T, S> {
     #[inline]
     fn as_ref(&self) -> &Self {
         self
     }
 }
 
-impl<T, S: VecStorage<T> + ?Sized> AsMut<VecInner<T, S>> for VecInner<T, S> {
+impl<T, S: VecStorage<T> + ?Sized> AsMut<Self> for VecInner<T, S> {
     #[inline]
     fn as_mut(&mut self) -> &mut Self {
         self


### PR DESCRIPTION
- **Fix `clippy::use_self` warnings**
- **Fix `clippy::too_long_first_doc_paragraph` warnings**
- **Fix `clippy::redundant_pub_crate` warnings**
- **Fix `clippy::option_if_let_else` warnings**

See #535
