### PR TITLE
Fix `pool::Arc` being enabled without atomics. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fixed bug in `IndexMap::truncate` that left the map in an inconsistent state.
+- Fixed compilation on `thumbv6m-none-eabi` without `portable-atomic` feature.
 - Fixed clippy lints.
 - Fixed `{arc,box,object}_pool!` emitting clippy lints.
 - Fixed the list of implemented data structures in the crate docs, by adding `Deque`,

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,3 @@
-#![deny(warnings)]
-
 use std::{
     env,
     error::Error,

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -54,6 +54,7 @@
 
 mod treiber;
 
+#[cfg(any(feature = "portable-atomic", target_has_atomic = "ptr"))]
 pub mod arc;
 pub mod boxed;
 pub mod object;

--- a/tests/tsan.rs
+++ b/tests/tsan.rs
@@ -1,6 +1,5 @@
 #![deny(rust_2018_compatibility)]
 #![deny(rust_2018_idioms)]
-#![deny(warnings)]
 
 use std::{ptr::addr_of_mut, thread};
 


### PR DESCRIPTION
Only deny warnings on CI: https://rust-unofficial.github.io/patterns/anti_patterns/deny-warnings.html

Fix `pool::Arc` being enabled without atomics. 

Fixes https://github.com/rust-embedded/heapless/issues/463.