### PR TITLE
Migrate SortedLinkedList to LenType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `LenT` generic to `Vec<T, N>` and `VecView<T>` to save memory when using a sane capacity value.
 - Added the `index_set` module.
 - Added the `index_map` module.
+- Migrated `Idx` generic for `SortedLinkedList` to use the new `LenType` trait, allowing for `Idx` inference.
 
 ### Changed
 

--- a/src/len_type.rs
+++ b/src/len_type.rs
@@ -41,7 +41,7 @@ pub trait Sealed:
 
     /// Converts `LenT` into `Some(usize)`, unless it's `Self::MAX`, where it returns `None`.
     #[inline]
-    fn option(self) -> Option<usize> {
+    fn to_non_max(self) -> Option<usize> {
         if self == Self::MAX {
             None
         } else {

--- a/src/len_type.rs
+++ b/src/len_type.rs
@@ -22,8 +22,10 @@ pub trait Sealed:
     const ZERO: Self;
     /// The one value of the integer type.
     const ONE: Self;
+    /// The maximum value of this type.
+    const MAX: Self;
     /// The maximum value of this type, as a `usize`.
-    const MAX: usize;
+    const MAX_USIZE: usize;
 
     /// An infallible conversion from `usize` to `LenT`.
     #[inline]
@@ -36,6 +38,16 @@ pub trait Sealed:
     fn into_usize(self) -> usize {
         self.try_into().unwrap()
     }
+
+    /// Converts `LenT` into `Some(usize)`, unless it's `Self::MAX`, where it returns `None`.
+    #[inline]
+    fn option(self) -> Option<usize> {
+        if self == Self::MAX {
+            None
+        } else {
+            Some(self.into_usize())
+        }
+    }
 }
 
 macro_rules! impl_lentype {
@@ -44,7 +56,8 @@ macro_rules! impl_lentype {
         impl Sealed for $LenT {
             const ZERO: Self = 0;
             const ONE: Self = 1;
-            const MAX: usize = Self::MAX as _;
+            const MAX: Self = Self::MAX;
+            const MAX_USIZE: usize = Self::MAX as _;
         }
 
         $(#[$meta])*
@@ -103,5 +116,5 @@ impl_lentodefault!(u16: 256, 300, 400, 500, 512, 600, 700, 800, 900, 1000, 1024,
 impl_lentodefault!(u32: 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 33554432, 67108864, 134217728, 268435456, 536870912, 1073741824, 2147483648);
 
 pub const fn check_capacity_fits<LenT: LenType, const N: usize>() {
-    assert!(LenT::MAX >= N, "The capacity is larger than `LenT` can hold, increase the size of `LenT` or reduce the capacity");
+    assert!(LenT::MAX_USIZE >= N, "The capacity is larger than `LenT` can hold, increase the size of `LenT` or reduce the capacity");
 }

--- a/src/sorted_linked_list.rs
+++ b/src/sorted_linked_list.rs
@@ -349,7 +349,7 @@ where
         self.write_data_in_node_at(new, value);
         self.free = self.node_at(new).next;
 
-        if let Some(head) = self.head.option() {
+        if let Some(head) = self.head.to_non_max() {
             // Check if we need to replace head
             if self
                 .read_data_in_node_at(head)
@@ -359,7 +359,7 @@ where
                 // It's not head, search the list for the correct placement
                 let mut current = head;
 
-                while let Some(next) = self.node_at(current).next.option() {
+                while let Some(next) = self.node_at(current).next.to_non_max() {
                     if self
                         .read_data_in_node_at(next)
                         .cmp(self.read_data_in_node_at(new))
@@ -443,7 +443,7 @@ where
     /// ```
     pub fn peek(&self) -> Option<&T> {
         self.head
-            .option()
+            .to_non_max()
             .map(|head| self.read_data_in_node_at(head))
     }
 
@@ -506,7 +506,7 @@ where
     /// ```
     #[inline]
     pub fn is_full(&self) -> bool {
-        self.free.option().is_none()
+        self.free.to_non_max().is_none()
     }
 
     /// Checks if the linked list is empty.
@@ -524,7 +524,7 @@ where
     /// ```
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.head.option().is_none()
+        self.head.to_non_max().is_none()
     }
 }
 
@@ -585,7 +585,7 @@ where
     where
         F: FnMut(&T) -> bool,
     {
-        let head = self.head.option()?;
+        let head = self.head.to_non_max()?;
 
         // Special-case, first element
         if f(self.read_data_in_node_at(head)) {
@@ -600,7 +600,7 @@ where
 
         let mut current = head;
 
-        while let Some(next) = self.node_at(current).next.option() {
+        while let Some(next) = self.node_at(current).next.to_non_max() {
             if f(self.read_data_in_node_at(next)) {
                 return Some(FindMutView {
                     is_head: false,
@@ -638,7 +638,7 @@ where
     type Item = &'a T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let index = self.index.option()?;
+        let index = self.index.to_non_max()?;
 
         let node = self.list.node_at(index);
         self.index = node.next;
@@ -798,17 +798,17 @@ where
 // {
 //     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 //         f.debug_struct("FindMut")
-//             .field("prev_index", &self.prev_index.option())
-//             .field("index", &self.index.option())
+//             .field("prev_index", &self.prev_index.to_non_max())
+//             .field("index", &self.index.to_non_max())
 //             .field(
 //                 "prev_value",
 //                 &self
 //                     .list
-//                     .read_data_in_node_at(self.prev_index.option().unwrap()),
+//                     .read_data_in_node_at(self.prev_index.to_non_max().unwrap()),
 //             )
 //             .field(
 //                 "value",
-//                 &self.list.read_data_in_node_at(self.index.option().unwrap()),
+//                 &self.list.read_data_in_node_at(self.index.to_non_max().unwrap()),
 //             )
 //             .finish()
 //     }
@@ -834,7 +834,7 @@ where
     fn drop(&mut self) {
         let mut index = self.head;
 
-        while let Some(i) = index.option() {
+        while let Some(i) = index.to_non_max() {
             let node = self.node_at_mut(i);
             index = node.next;
 

--- a/src/sorted_linked_list.rs
+++ b/src/sorted_linked_list.rs
@@ -8,7 +8,7 @@
 //!
 //! ```
 //! use heapless::sorted_linked_list::{Max, SortedLinkedList};
-//! let mut ll: SortedLinkedList<_, _, Max, 3> = SortedLinkedList::new_usize();
+//! let mut ll: SortedLinkedList<_, Max, 3> = SortedLinkedList::new_u8();
 //!
 //! // The largest value will always be first
 //! ll.push(1).unwrap();
@@ -34,7 +34,7 @@ use core::ops::{Deref, DerefMut};
 use core::ptr;
 
 mod storage {
-    use super::{Node, SortedLinkedListIndex, SortedLinkedListInner, SortedLinkedListView};
+    use super::{LenType, Node, SortedLinkedListInner, SortedLinkedListView};
 
     /// Trait defining how data for a container is stored.
     ///
@@ -68,15 +68,15 @@ mod storage {
         fn borrow_mut(&mut self) -> &mut [Node<T, Idx>];
         fn as_view<K>(
             this: &SortedLinkedListInner<T, Idx, K, Self>,
-        ) -> &SortedLinkedListView<T, Idx, K>
+        ) -> &SortedLinkedListView<T, K, Idx>
         where
-            Idx: SortedLinkedListIndex,
+            Idx: LenType,
             Self: SortedLinkedListStorage<T, Idx>;
         fn as_mut_view<K>(
             this: &mut SortedLinkedListInner<T, Idx, K, Self>,
-        ) -> &mut SortedLinkedListView<T, Idx, K>
+        ) -> &mut SortedLinkedListView<T, K, Idx>
         where
-            Idx: SortedLinkedListIndex,
+            Idx: LenType,
             Self: SortedLinkedListStorage<T, Idx>;
     }
 
@@ -102,19 +102,19 @@ mod storage {
         }
         fn as_view<K>(
             this: &SortedLinkedListInner<T, Idx, K, Self>,
-        ) -> &SortedLinkedListView<T, Idx, K>
+        ) -> &SortedLinkedListView<T, K, Idx>
         where
             Self: SortedLinkedListStorage<T, Idx>,
-            Idx: SortedLinkedListIndex,
+            Idx: LenType,
         {
             this
         }
         fn as_mut_view<K>(
             this: &mut SortedLinkedListInner<T, Idx, K, Self>,
-        ) -> &mut SortedLinkedListView<T, Idx, K>
+        ) -> &mut SortedLinkedListView<T, K, Idx>
         where
             Self: SortedLinkedListStorage<T, Idx>,
-            Idx: SortedLinkedListIndex,
+            Idx: LenType,
         {
             this
         }
@@ -133,19 +133,19 @@ mod storage {
         }
         fn as_view<K>(
             this: &SortedLinkedListInner<T, Idx, K, Self>,
-        ) -> &SortedLinkedListView<T, Idx, K>
+        ) -> &SortedLinkedListView<T, K, Idx>
         where
             Self: SortedLinkedListStorage<T, Idx>,
-            Idx: SortedLinkedListIndex,
+            Idx: LenType,
         {
             this
         }
         fn as_mut_view<K>(
             this: &mut SortedLinkedListInner<T, Idx, K, Self>,
-        ) -> &mut SortedLinkedListView<T, Idx, K>
+        ) -> &mut SortedLinkedListView<T, K, Idx>
         where
             Self: SortedLinkedListStorage<T, Idx>,
-            Idx: SortedLinkedListIndex,
+            Idx: LenType,
         {
             this
         }
@@ -156,17 +156,7 @@ pub use storage::{
     OwnedSortedLinkedListStorage, SortedLinkedListStorage, ViewSortedLinkedListStorage,
 };
 
-/// Trait for defining an index for the linked list, never implemented by users.
-pub trait SortedLinkedListIndex: Copy {
-    #[doc(hidden)]
-    unsafe fn new_unchecked(val: usize) -> Self;
-    #[doc(hidden)]
-    unsafe fn get_unchecked(self) -> usize;
-    #[doc(hidden)]
-    fn option(self) -> Option<usize>;
-    #[doc(hidden)]
-    fn none() -> Self;
-}
+use crate::len_type::{DefaultLenType, LenType};
 
 /// Marker for Min sorted [`SortedLinkedList`].
 pub struct Min;
@@ -212,7 +202,7 @@ pub struct Node<T, Idx> {
 /// struct if you want to write code that's generic over both.
 pub struct SortedLinkedListInner<T, Idx, K, S>
 where
-    Idx: SortedLinkedListIndex,
+    Idx: LenType,
     S: SortedLinkedListStorage<T, Idx> + ?Sized,
 {
     head: Idx,
@@ -222,84 +212,41 @@ where
 }
 
 /// The linked list.
-pub type SortedLinkedList<T, Idx, K, const N: usize> =
+pub type SortedLinkedList<T, K, const N: usize, Idx = DefaultLenType<N>> =
     SortedLinkedListInner<T, Idx, K, OwnedSortedLinkedListStorage<T, Idx, N>>;
 
 /// The linked list.
-pub type SortedLinkedListView<T, Idx, K> =
+pub type SortedLinkedListView<T, K, Idx> =
     SortedLinkedListInner<T, Idx, K, ViewSortedLinkedListStorage<T, Idx>>;
 
-// Internal macro for generating indexes for the linkedlist and const new for the linked list
-macro_rules! impl_index_and_const_new {
-    ($name:ident, $ty:ty, $new_name:ident, $max_val:expr) => {
-        /// Index for the [`SortedLinkedList`] with specific backing storage.
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-        pub struct $name($ty);
-
-        impl SortedLinkedListIndex for $name {
-            #[inline(always)]
-            unsafe fn new_unchecked(val: usize) -> Self {
-                Self::new_unchecked(val as $ty)
-            }
-
-            /// This is only valid if `self.option()` is not `None`.
-            #[inline(always)]
-            unsafe fn get_unchecked(self) -> usize {
-                self.0 as usize
-            }
-
-            #[inline(always)]
-            fn option(self) -> Option<usize> {
-                if self.0 == <$ty>::MAX {
-                    None
-                } else {
-                    Some(self.0 as usize)
-                }
-            }
-
-            #[inline(always)]
-            fn none() -> Self {
-                Self::none()
-            }
-        }
-
-        impl $name {
-            /// Needed for a `const fn new()`.
-            #[inline]
-            const unsafe fn new_unchecked(value: $ty) -> Self {
-                $name(value)
-            }
-
-            /// Needed for a `const fn new()`.
-            #[inline]
-            const fn none() -> Self {
-                $name(<$ty>::MAX)
-            }
-        }
-
-        impl<T, K, const N: usize> SortedLinkedList<T, $name, K, N> {
-            const UNINIT: Node<T, $name> = Node {
-                val: MaybeUninit::uninit(),
-                next: $name::none(),
-            };
-
+macro_rules! impl_const_new {
+    ($ty:ty, $new_name:ident) => {
+        impl<T, K, const N: usize> SortedLinkedList<T, K, N, $ty> {
             /// Create a new linked list.
             pub const fn $new_name() -> Self {
                 const {
-                    assert!(N < $max_val);
+                    assert!(
+                        (<$ty>::MAX as usize) >= (N + 1),
+                        "The capacity is larger than `LenT` can hold, increase the size of `LenT` or reduce the capacity"
+                    );
                 }
 
                 let mut list = SortedLinkedList {
                     list: OwnedSortedLinkedListStorage {
-                        buffer: [Self::UNINIT; N],
+                        buffer: [const {
+                            Node {
+                                val: MaybeUninit::uninit(),
+                                next: <$ty>::MAX,
+                            }
+                        }; N],
                     },
-                    head: $name::none(),
-                    free: unsafe { $name::new_unchecked(0) },
+                    head: <$ty>::MAX,
+                    free: 0,
                     phantom: PhantomData,
                 };
 
                 if N == 0 {
-                    list.free = $name::none();
+                    list.free = <$ty>::MAX;
                     return list;
                 }
 
@@ -307,7 +254,7 @@ macro_rules! impl_index_and_const_new {
 
                 // Initialize indexes
                 while free < N - 1 {
-                    list.list.buffer[free].next = unsafe { $name::new_unchecked(free as $ty + 1) };
+                    list.list.buffer[free].next = free as $ty + 1;
                     free += 1;
                 }
 
@@ -317,22 +264,22 @@ macro_rules! impl_index_and_const_new {
     };
 }
 
-impl_index_and_const_new!(LinkedIndexU8, u8, new_u8, { u8::MAX as usize - 1 });
-impl_index_and_const_new!(LinkedIndexU16, u16, new_u16, { u16::MAX as usize - 1 });
-impl_index_and_const_new!(LinkedIndexUsize, usize, new_usize, { usize::MAX - 1 });
+impl_const_new!(u8, new_u8);
+impl_const_new!(u16, new_u16);
+impl_const_new!(usize, new_usize);
 
 impl<T, Idx, K, S> SortedLinkedListInner<T, Idx, K, S>
 where
-    Idx: SortedLinkedListIndex,
+    Idx: LenType,
     S: SortedLinkedListStorage<T, Idx> + ?Sized,
 {
     /// Get a reference to the `SortedLinkedList`, erasing the `N` const-generic.
-    pub fn as_view(&self) -> &SortedLinkedListView<T, Idx, K> {
+    pub fn as_view(&self) -> &SortedLinkedListView<T, K, Idx> {
         S::as_view(self)
     }
 
     /// Get a mutable reference to the `Vec`, erasing the `N` const-generic.
-    pub fn as_mut_view(&mut self) -> &mut SortedLinkedListView<T, Idx, K> {
+    pub fn as_mut_view(&mut self) -> &mut SortedLinkedListView<T, K, Idx> {
         S::as_mut_view(self)
     }
 
@@ -384,7 +331,7 @@ where
 impl<T, Idx, K, S> SortedLinkedListInner<T, Idx, K, S>
 where
     T: Ord,
-    Idx: SortedLinkedListIndex,
+    Idx: LenType,
     K: Kind,
     S: SortedLinkedListStorage<T, Idx> + ?Sized,
 {
@@ -396,7 +343,7 @@ where
     ///
     /// Assumes that the list is not full.
     pub unsafe fn push_unchecked(&mut self, value: T) {
-        let new = self.free.get_unchecked();
+        let new = self.free.into_usize();
 
         // Store the data and update the next free spot
         self.write_data_in_node_at(new, value);
@@ -425,14 +372,14 @@ where
                 }
 
                 self.node_at_mut(new).next = self.node_at(current).next;
-                self.node_at_mut(current).next = Idx::new_unchecked(new);
+                self.node_at_mut(current).next = Idx::from_usize(new);
             } else {
                 self.node_at_mut(new).next = self.head;
-                self.head = Idx::new_unchecked(new);
+                self.head = Idx::from_usize(new);
             }
         } else {
             self.node_at_mut(new).next = self.head;
-            self.head = Idx::new_unchecked(new);
+            self.head = Idx::from_usize(new);
         }
     }
 
@@ -444,7 +391,7 @@ where
     ///
     /// ```
     /// use heapless::sorted_linked_list::{Max, SortedLinkedList};
-    /// let mut ll: SortedLinkedList<_, _, Max, 3> = SortedLinkedList::new_usize();
+    /// let mut ll: SortedLinkedList<_, Max, 3> = SortedLinkedList::new_u8();
     ///
     /// // The largest value will always be first
     /// ll.push(1).unwrap();
@@ -474,7 +421,7 @@ where
     ///
     /// ```
     /// use heapless::sorted_linked_list::{Max, Min, SortedLinkedList};
-    /// let mut ll_max: SortedLinkedList<_, _, Max, 3> = SortedLinkedList::new_usize();
+    /// let mut ll_max: SortedLinkedList<_, Max, 3> = SortedLinkedList::new_u8();
     ///
     /// // The largest value will always be first
     /// ll_max.push(1).unwrap();
@@ -484,7 +431,7 @@ where
     /// ll_max.push(3).unwrap();
     /// assert_eq!(ll_max.peek(), Some(&3));
     ///
-    /// let mut ll_min: SortedLinkedList<_, _, Min, 3> = SortedLinkedList::new_usize();
+    /// let mut ll_min: SortedLinkedList<_, Min, 3> = SortedLinkedList::new_u8();
     ///
     /// // The Smallest value will always be first
     /// ll_min.push(3).unwrap();
@@ -506,11 +453,11 @@ where
     ///
     /// Assumes that the list is not empty.
     pub unsafe fn pop_unchecked(&mut self) -> T {
-        let head = self.head.get_unchecked();
+        let head = self.head.into_usize();
         let current = head;
         self.head = self.node_at(head).next;
         self.node_at_mut(current).next = self.free;
-        self.free = Idx::new_unchecked(current);
+        self.free = Idx::from_usize(current);
 
         self.extract_data_in_node_at(current)
     }
@@ -523,7 +470,7 @@ where
     ///
     /// ```
     /// use heapless::sorted_linked_list::{Max, SortedLinkedList};
-    /// let mut ll: SortedLinkedList<_, _, Max, 3> = SortedLinkedList::new_usize();
+    /// let mut ll: SortedLinkedList<_, Max, 3> = SortedLinkedList::new_u8();
     ///
     /// ll.push(1).unwrap();
     /// ll.push(2).unwrap();
@@ -546,7 +493,7 @@ where
     ///
     /// ```
     /// use heapless::sorted_linked_list::{Max, SortedLinkedList};
-    /// let mut ll: SortedLinkedList<_, _, Max, 3> = SortedLinkedList::new_usize();
+    /// let mut ll: SortedLinkedList<_, Max, 3> = SortedLinkedList::new_u8();
     ///
     /// assert_eq!(ll.is_full(), false);
     ///
@@ -568,7 +515,7 @@ where
     ///
     /// ```
     /// use heapless::sorted_linked_list::{Max, SortedLinkedList};
-    /// let mut ll: SortedLinkedList<_, _, Max, 3> = SortedLinkedList::new_usize();
+    /// let mut ll: SortedLinkedList<_, Max, 3> = SortedLinkedList::new_u8();
     ///
     /// assert_eq!(ll.is_empty(), true);
     ///
@@ -584,7 +531,7 @@ where
 impl<T, Idx, K, S> SortedLinkedListInner<T, Idx, K, S>
 where
     T: Ord,
-    Idx: SortedLinkedListIndex,
+    Idx: LenType,
     K: Kind,
     S: SortedLinkedListStorage<T, Idx> + ?Sized,
 {
@@ -594,7 +541,7 @@ where
     ///
     /// ```
     /// use heapless::sorted_linked_list::{Max, SortedLinkedList};
-    /// let mut ll: SortedLinkedList<_, _, Max, 3> = SortedLinkedList::new_usize();
+    /// let mut ll: SortedLinkedList<_, Max, 3> = SortedLinkedList::new_u8();
     ///
     /// ll.push(1).unwrap();
     /// ll.push(2).unwrap();
@@ -618,7 +565,7 @@ where
     ///
     /// ```
     /// use heapless::sorted_linked_list::{Max, SortedLinkedList};
-    /// let mut ll: SortedLinkedList<_, _, Max, 3> = SortedLinkedList::new_usize();
+    /// let mut ll: SortedLinkedList<_, Max, 3> = SortedLinkedList::new_u8();
     ///
     /// ll.push(1).unwrap();
     /// ll.push(2).unwrap();
@@ -644,7 +591,7 @@ where
         if f(self.read_data_in_node_at(head)) {
             return Some(FindMutView {
                 is_head: true,
-                prev_index: Idx::none(),
+                prev_index: Idx::MAX,
                 index: self.head,
                 list: S::as_mut_view(self),
                 maybe_changed: false,
@@ -657,8 +604,8 @@ where
             if f(self.read_data_in_node_at(next)) {
                 return Some(FindMutView {
                     is_head: false,
-                    prev_index: unsafe { Idx::new_unchecked(current) },
-                    index: unsafe { Idx::new_unchecked(next) },
+                    prev_index: Idx::from_usize(current),
+                    index: Idx::from_usize(next),
                     list: S::as_mut_view(self),
                     maybe_changed: false,
                 });
@@ -675,7 +622,7 @@ where
 pub struct IterView<'a, T, Idx, K>
 where
     T: Ord,
-    Idx: SortedLinkedListIndex,
+    Idx: LenType,
     K: Kind,
 {
     list: &'a SortedLinkedListInner<T, Idx, K, ViewSortedLinkedListStorage<T, Idx>>,
@@ -685,7 +632,7 @@ where
 impl<'a, T, Idx, K> Iterator for IterView<'a, T, Idx, K>
 where
     T: Ord,
-    Idx: SortedLinkedListIndex,
+    Idx: LenType,
     K: Kind,
 {
     type Item = &'a T;
@@ -704,10 +651,10 @@ where
 pub struct FindMutView<'a, T, Idx, K>
 where
     T: Ord,
-    Idx: SortedLinkedListIndex,
+    Idx: LenType,
     K: Kind,
 {
-    list: &'a mut SortedLinkedListView<T, Idx, K>,
+    list: &'a mut SortedLinkedListView<T, K, Idx>,
     is_head: bool,
     prev_index: Idx,
     index: Idx,
@@ -717,7 +664,7 @@ where
 impl<T, Idx, K> FindMutView<'_, T, Idx, K>
 where
     T: Ord,
-    Idx: SortedLinkedListIndex,
+    Idx: LenType,
     K: Kind,
 {
     fn pop_internal(&mut self) -> T {
@@ -726,8 +673,8 @@ where
             unsafe { self.list.pop_unchecked() }
         } else {
             // Somewhere in the list
-            let prev = unsafe { self.prev_index.get_unchecked() };
-            let curr = unsafe { self.index.get_unchecked() };
+            let prev = self.prev_index.into_usize();
+            let curr = self.index.into_usize();
 
             // Re-point the previous index
             self.list.node_at_mut(prev).next = self.list.node_at_mut(curr).next;
@@ -748,7 +695,7 @@ where
     ///
     /// ```
     /// use heapless::sorted_linked_list::{Max, SortedLinkedList};
-    /// let mut ll: SortedLinkedList<_, _, Max, 3> = SortedLinkedList::new_usize();
+    /// let mut ll: SortedLinkedList<_, Max, 3> = SortedLinkedList::new_u8();
     ///
     /// ll.push(1).unwrap();
     /// ll.push(2).unwrap();
@@ -778,7 +725,7 @@ where
     ///
     /// ```
     /// use heapless::sorted_linked_list::{Max, SortedLinkedList};
-    /// let mut ll: SortedLinkedList<_, _, Max, 3> = SortedLinkedList::new_usize();
+    /// let mut ll: SortedLinkedList<_, Max, 3> = SortedLinkedList::new_u8();
     ///
     /// ll.push(1).unwrap();
     /// ll.push(2).unwrap();
@@ -805,7 +752,7 @@ where
 impl<T, Idx, K> Drop for FindMutView<'_, T, Idx, K>
 where
     T: Ord,
-    Idx: SortedLinkedListIndex,
+    Idx: LenType,
     K: Kind,
 {
     fn drop(&mut self) {
@@ -820,27 +767,25 @@ where
 impl<T, Idx, K> Deref for FindMutView<'_, T, Idx, K>
 where
     T: Ord,
-    Idx: SortedLinkedListIndex,
+    Idx: LenType,
     K: Kind,
 {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        self.list
-            .read_data_in_node_at(unsafe { self.index.get_unchecked() })
+        self.list.read_data_in_node_at(self.index.into_usize())
     }
 }
 
 impl<T, Idx, K> DerefMut for FindMutView<'_, T, Idx, K>
 where
     T: Ord,
-    Idx: SortedLinkedListIndex,
+    Idx: LenType,
     K: Kind,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.maybe_changed = true;
-        self.list
-            .read_mut_data_in_node_at(unsafe { self.index.get_unchecked() })
+        self.list.read_mut_data_in_node_at(self.index.into_usize())
     }
 }
 
@@ -848,7 +793,7 @@ where
 // impl<T, Idx, K, const N: usize> fmt::Debug for FindMut<'_, T, Idx, K, N>
 // where
 //     T: Ord + core::fmt::Debug,
-//     Idx: SortedLinkedListIndex,
+//     Idx: LenType,
 //     K: Kind,
 // {
 //     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -872,7 +817,7 @@ where
 impl<T, Idx, K, S> fmt::Debug for SortedLinkedListInner<T, Idx, K, S>
 where
     T: Ord + core::fmt::Debug,
-    Idx: SortedLinkedListIndex,
+    Idx: LenType,
     K: Kind,
     S: ?Sized + SortedLinkedListStorage<T, Idx>,
 {
@@ -883,7 +828,7 @@ where
 
 impl<T, Idx, K, S> Drop for SortedLinkedListInner<T, Idx, K, S>
 where
-    Idx: SortedLinkedListIndex,
+    Idx: LenType,
     S: SortedLinkedListStorage<T, Idx> + ?Sized,
 {
     fn drop(&mut self) {
@@ -907,20 +852,18 @@ mod tests {
     use super::*;
 
     // Ensure a `SortedLinkedList` containing `!Send` values stays `!Send` itself.
-    assert_not_impl_any!(SortedLinkedList<*const (), LinkedIndexU8, (), 4>: Send);
+    assert_not_impl_any!(SortedLinkedList<*const (), (), 4>: Send);
 
     #[test]
     fn const_new() {
-        static mut _V1: SortedLinkedList<u32, LinkedIndexU8, Max, 100> = SortedLinkedList::new_u8();
-        static mut _V2: SortedLinkedList<u32, LinkedIndexU16, Max, 10_000> =
-            SortedLinkedList::new_u16();
-        static mut _V3: SortedLinkedList<u32, LinkedIndexUsize, Max, 100_000> =
-            SortedLinkedList::new_usize();
+        static mut _V1: SortedLinkedList<u32, Max, 100, u8> = SortedLinkedList::new_u8();
+        static mut _V2: SortedLinkedList<u32, Max, 10_000, u16> = SortedLinkedList::new_u16();
+        static mut _V3: SortedLinkedList<u32, Max, 100_000, usize> = SortedLinkedList::new_usize();
     }
 
     #[test]
     fn test_peek() {
-        let mut ll: SortedLinkedList<u32, LinkedIndexUsize, Max, 3> = SortedLinkedList::new_usize();
+        let mut ll: SortedLinkedList<u32, Max, 3> = SortedLinkedList::new_u8();
 
         ll.push(1).unwrap();
         assert_eq!(ll.peek().unwrap(), &1);
@@ -931,7 +874,7 @@ mod tests {
         ll.push(3).unwrap();
         assert_eq!(ll.peek().unwrap(), &3);
 
-        let mut ll: SortedLinkedList<u32, LinkedIndexUsize, Min, 3> = SortedLinkedList::new_usize();
+        let mut ll: SortedLinkedList<u32, Min, 3> = SortedLinkedList::new_u8();
 
         ll.push(2).unwrap();
         assert_eq!(ll.peek().unwrap(), &2);
@@ -945,7 +888,7 @@ mod tests {
 
     #[test]
     fn test_full() {
-        let mut ll: SortedLinkedList<u32, LinkedIndexUsize, Max, 3> = SortedLinkedList::new_usize();
+        let mut ll: SortedLinkedList<u32, Max, 3> = SortedLinkedList::new_u8();
         ll.push(1).unwrap();
         ll.push(2).unwrap();
         ll.push(3).unwrap();
@@ -955,14 +898,14 @@ mod tests {
 
     #[test]
     fn test_empty() {
-        let ll: SortedLinkedList<u32, LinkedIndexUsize, Max, 3> = SortedLinkedList::new_usize();
+        let ll: SortedLinkedList<u32, Max, 3> = SortedLinkedList::new_u8();
 
         assert!(ll.is_empty());
     }
 
     #[test]
     fn test_zero_size() {
-        let ll: SortedLinkedList<u32, LinkedIndexUsize, Max, 0> = SortedLinkedList::new_usize();
+        let ll: SortedLinkedList<u32, Max, 0> = SortedLinkedList::new_u8();
 
         assert!(ll.is_empty());
         assert!(ll.is_full());
@@ -970,7 +913,7 @@ mod tests {
 
     #[test]
     fn test_rejected_push() {
-        let mut ll: SortedLinkedList<u32, LinkedIndexUsize, Max, 3> = SortedLinkedList::new_usize();
+        let mut ll: SortedLinkedList<u32, Max, 3> = SortedLinkedList::new_u8();
         ll.push(1).unwrap();
         ll.push(2).unwrap();
         ll.push(3).unwrap();
@@ -983,7 +926,7 @@ mod tests {
 
     #[test]
     fn test_updating() {
-        let mut ll: SortedLinkedList<u32, LinkedIndexUsize, Max, 3> = SortedLinkedList::new_usize();
+        let mut ll: SortedLinkedList<u32, Max, 3> = SortedLinkedList::new_u8();
         ll.push(1).unwrap();
         ll.push(2).unwrap();
         ll.push(3).unwrap();
@@ -1010,7 +953,7 @@ mod tests {
 
     #[test]
     fn test_updating_1() {
-        let mut ll: SortedLinkedList<u32, LinkedIndexUsize, Max, 3> = SortedLinkedList::new_usize();
+        let mut ll: SortedLinkedList<u32, Max, 3> = SortedLinkedList::new_u8();
         ll.push(1).unwrap();
 
         let v = ll.pop().unwrap();
@@ -1020,7 +963,7 @@ mod tests {
 
     #[test]
     fn test_updating_2() {
-        let mut ll: SortedLinkedList<u32, LinkedIndexUsize, Max, 3> = SortedLinkedList::new_usize();
+        let mut ll: SortedLinkedList<u32, Max, 3> = SortedLinkedList::new_u8();
         ll.push(1).unwrap();
 
         let mut find = ll.find_mut(|v| *v == 1).unwrap();
@@ -1032,13 +975,13 @@ mod tests {
     }
 
     fn _test_variance<'a: 'b, 'b>(
-        x: SortedLinkedList<&'a (), LinkedIndexUsize, Max, 42>,
-    ) -> SortedLinkedList<&'b (), LinkedIndexUsize, Max, 42> {
+        x: SortedLinkedList<&'a (), Max, 42, u8>,
+    ) -> SortedLinkedList<&'b (), Max, 42, u8> {
         x
     }
     fn _test_variance_view<'a: 'b, 'b, 'c>(
-        x: &'c SortedLinkedListView<&'a (), LinkedIndexUsize, Max>,
-    ) -> &'c SortedLinkedListView<&'b (), LinkedIndexUsize, Max> {
+        x: &'c SortedLinkedListView<&'a (), Max, u8>,
+    ) -> &'c SortedLinkedListView<&'b (), Max, u8> {
         x
     }
 }


### PR DESCRIPTION
Part of #551.

The previous `SortedLinkedListIndex` seemed to store `Option<NonMaxLenT>` and required unsafe calls to get at the raw value without checking `::MAX`.... but none of those unsafe calls had safety comments and removing the unsafety shouldn't make the external interface unsound.