### PR TITLE
Optimize size of heapless::Vec<_, 0> to 0 bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added the `index_map` module.
 - Migrated `Idx` generic for `SortedLinkedList` to use the new `LenType` trait, allowing for `Idx` inference.
 - Added similar `LenT` generic to `String`.
+- Optimize size of zero capacity `Vec<T, 0>` to be 0 bytes
 
 ### Changed
 

--- a/src/len_type.rs
+++ b/src/len_type.rs
@@ -21,11 +21,15 @@ pub trait Sealed:
     /// The zero value of the integer type.
     const ZERO: Self;
     /// The one value of the integer type.
-    const ONE: Self;
-    /// The maximum value of this type.
     const MAX: Self;
     /// The maximum value of this type, as a `usize`.
     const MAX_USIZE: usize;
+
+    /// The one value of the integer type.
+    ///
+    /// It's a function instead of constant because we want to have implementation which panics for
+    /// type `ZeroLenType`
+    fn one() -> Self;
 
     /// An infallible conversion from `usize` to `LenT`.
     #[inline]
@@ -55,9 +59,12 @@ macro_rules! impl_lentype {
         $(#[$meta])*
         impl Sealed for $LenT {
             const ZERO: Self = 0;
-            const ONE: Self = 1;
             const MAX: Self = Self::MAX;
             const MAX_USIZE: usize = Self::MAX as _;
+
+            fn one() -> Self {
+                1
+            }
         }
 
         $(#[$meta])*
@@ -111,11 +118,153 @@ pub trait SmallestLenType {
 #[allow(rustdoc::private_intra_doc_links)] // Only publically exposed via `crate::_export`
 pub type DefaultLenType<const N: usize> = <Const<N> as SmallestLenType>::Type;
 
-impl_lentodefault!(u8: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255);
+impl_lentodefault!(ZeroLenType: 0);
+impl_lentodefault!(u8: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255);
 impl_lentodefault!(u16: 256, 300, 400, 500, 512, 600, 700, 800, 900, 1000, 1024, 2000, 2048, 4000, 4096, 8000, 8192, 16000, 16384, 32000, 32768, 65000, 65535);
 #[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 impl_lentodefault!(u32: 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 33554432, 67108864, 134217728, 268435456, 536870912, 1073741824, 2147483648);
 
 pub const fn check_capacity_fits<LenT: LenType, const N: usize>() {
     assert!(LenT::MAX_USIZE >= N, "The capacity is larger than `LenT` can hold, increase the size of `LenT` or reduce the capacity");
+}
+
+/// Container with 0 capacity always has length 0, so there is no need to track length of such containers at all.
+///
+/// This type is used as a placeholder for length of container with 0 capacity. It allows optimizing total size of
+/// containers like this to 0 bytes.
+///
+/// Logically, this type always stores value 0. Because of this ZeroLenType::one() panics and should never be called.
+#[doc(hidden)]
+#[derive(Copy, Clone, PartialEq, PartialOrd)]
+pub struct ZeroLenType;
+
+impl Debug for ZeroLenType {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "0")
+    }
+}
+
+impl Display for ZeroLenType {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "0")
+    }
+}
+
+impl Sealed for ZeroLenType {
+    const ZERO: Self = Self;
+
+    const MAX: Self = Self;
+    const MAX_USIZE: usize = 0;
+
+    #[inline]
+    fn one() -> Self {
+        panic!("ZeroLenType cannot represent value 1");
+    }
+}
+
+impl LenType for ZeroLenType {}
+
+impl Add for ZeroLenType {
+    type Output = Self;
+
+    fn add(self, _rhs: Self) -> Self::Output {
+        Self::ZERO
+    }
+}
+
+impl AddAssign for ZeroLenType {
+    fn add_assign(&mut self, _rhs: Self) {}
+}
+
+impl Sub for ZeroLenType {
+    type Output = Self;
+
+    fn sub(self, _rhs: Self) -> Self::Output {
+        Self::ZERO
+    }
+}
+
+impl SubAssign for ZeroLenType {
+    fn sub_assign(&mut self, _rhs: Self) {}
+}
+
+#[doc(hidden)]
+#[derive(Debug, PartialEq)]
+pub struct ZeroLenTypeTryFromError;
+
+impl TryFrom<usize> for ZeroLenType {
+    type Error = ZeroLenTypeTryFromError;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        if value > 0 {
+            return Err(ZeroLenTypeTryFromError);
+        }
+
+        Ok(Self::ZERO)
+    }
+}
+
+impl TryInto<usize> for ZeroLenType {
+    type Error = ();
+
+    fn try_into(self) -> Result<usize, Self::Error> {
+        Ok(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::len_type::{Sealed, ZeroLenType, ZeroLenTypeTryFromError};
+
+    #[test]
+    pub fn test_zero_len_type_conversions() {
+        assert_eq!(ZeroLenType::into_usize(ZeroLenType::ZERO), 0_usize);
+        assert_eq!(ZeroLenType::from_usize(0_usize), ZeroLenType::ZERO);
+
+        assert_eq!(ZeroLenType::ZERO.try_into(), Ok(0_usize));
+        assert_eq!(ZeroLenType::try_from(0_usize), Ok(ZeroLenType::ZERO));
+        assert_eq!(ZeroLenType::try_from(1_usize), Err(ZeroLenTypeTryFromError));
+    }
+
+    #[test]
+    #[should_panic]
+    pub fn test_zero_len_type_one() {
+        ZeroLenType::one();
+    }
+
+    #[test]
+    #[should_panic]
+    pub fn test_zero_len_type_one_usize() {
+        ZeroLenType::from_usize(1);
+    }
+
+    #[test]
+    pub fn test_zero_len_type_constants() {
+        assert_eq!(ZeroLenType::ZERO, ZeroLenType);
+        assert_eq!(ZeroLenType::MAX, ZeroLenType);
+        assert_eq!(ZeroLenType::MAX_USIZE, 0_usize);
+    }
+
+    #[test]
+    pub fn test_zero_len_type_size() {
+        assert_eq!(core::mem::size_of::<ZeroLenType>(), 0);
+    }
+
+    #[test]
+    pub fn test_zero_len_type_ops() {
+        assert_eq!(ZeroLenType::ZERO + ZeroLenType::ZERO, ZeroLenType::ZERO);
+        assert_eq!(ZeroLenType::ZERO - ZeroLenType::ZERO, ZeroLenType::ZERO);
+
+        let mut zero = ZeroLenType::ZERO;
+        zero += ZeroLenType::ZERO;
+        assert_eq!(zero, ZeroLenType::ZERO);
+        zero -= ZeroLenType::ZERO;
+        assert_eq!(zero, ZeroLenType::ZERO);
+    }
+
+    #[test]
+    pub fn test_zero_len_type_debug() {
+        assert_eq!(format!("{}", ZeroLenType), "0");
+        assert_eq!(format!("{:?}", ZeroLenType), "0");
+    }
 }

--- a/src/sorted_linked_list.rs
+++ b/src/sorted_linked_list.rs
@@ -905,7 +905,7 @@ mod tests {
 
     #[test]
     fn test_zero_size() {
-        let ll: SortedLinkedList<u32, Max, 0> = SortedLinkedList::new_u8();
+        let ll: SortedLinkedList<u32, Max, 0, u8> = SortedLinkedList::new_u8();
 
         assert!(ll.is_empty());
         assert!(ll.is_full());

--- a/src/string/mod.rs
+++ b/src/string/mod.rs
@@ -1236,4 +1236,29 @@ mod tests {
         let formatted = format!(2; "123");
         assert_eq!(formatted, Err(core::fmt::Error));
     }
+
+    #[test]
+    fn zero_capacity() {
+        let mut s: String<0> = String::new();
+        // Validate capacity
+        assert_eq!(s.capacity(), 0);
+
+        // Make sure there is no capacity
+        assert!(s.push('a').is_err());
+
+        // Validate length
+        assert_eq!(s.len(), 0);
+
+        // Validate pop
+        assert_eq!(s.pop(), None);
+
+        // Validate slice
+        assert_eq!(s.as_str(), "");
+
+        // Validate empty
+        assert!(s.is_empty());
+
+        // Size of string with zero capacity should be 0 bytes because of `ZeroLenType` optimization
+        assert_eq!(core::mem::size_of_val(&s), 0);
+    }
 }


### PR DESCRIPTION
If Vec has 0 capacity, it can store only 0 elements, so its len can be assumed to be always 0.

I'm updating `DefaultLenType` to have a special case: `DefaultLenType<0>` will be represented by zero sized type which always has value 0.

This allows reducing size of `heapless::Vec<u8, 0>` from 8 bytes to 0 bytes.