### PR TITLE
WIP/RFC: shift_remove and friends

### DIFF
--- a/src/index_map.rs
+++ b/src/index_map.rs
@@ -306,7 +306,7 @@ where
             .retain_mut(|entry| keep(&mut entry.key, &mut entry.value));
 
         if self.entries.len() < self.indices.len() {
-            self.after_removal()
+            self.after_removal();
         }
     }
 
@@ -1266,7 +1266,7 @@ where
     /// remaining items. This maintains the remaining elements' relative
     /// insertion order, but is a more expensive operation
     ///
-    /// Return `None` if `index` is not in 0..len().
+    /// Return `None` if `index` is not in `0..len()`.
     ///
     /// Computes in *O*(n) time (average).
     ///


### PR DESCRIPTION
Per #557, I took a stab at implementing the `shift_remove_*` family of functions from upstream `IndexMap`. I'm sure there's better ways to do the things I did; there are some todo's around exactly how to do the fixup after removing from `entries`. I factored out the re-calculation logic from `.retain`, but recalculating everything is probably overly conservative.

Also, you may not even want these API functions. No worries if so! But if you're interested, I'm happy to make changes or re-do things.