### PR TITLE
Fix #559: IndexMap::truncate leaves map in inconsistent state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed bug in `IndexMap::truncate` that left the map in an inconsistent state.
 - Fixed clippy lints.
 - Fixed `{arc,box,object}_pool!` emitting clippy lints.
 - Fixed the list of implemented data structures in the crate docs, by adding `Deque`,

--- a/src/index_map.rs
+++ b/src/index_map.rs
@@ -1245,7 +1245,7 @@ where
     ///
     /// If `len` is greater than the map's current length, this has no effect.
     ///
-    /// Computes in *O*(1) time (average).
+    /// Computes in *O*(n) time (average).
     ///
     /// # Examples
     ///
@@ -1267,6 +1267,15 @@ where
     /// ```
     pub fn truncate(&mut self, len: usize) {
         self.core.entries.truncate(len);
+
+        if self.core.indices.len() > self.core.entries.len() {
+            for index in self.core.indices.iter_mut() {
+                match index {
+                    Some(pos) if pos.index() >= len => *index = None,
+                    _ => (),
+                }
+            }
+        }
     }
 
     /* Private API */

--- a/src/index_map.rs
+++ b/src/index_map.rs
@@ -1258,6 +1258,7 @@ where
     /// map.insert(1, "c").unwrap();
     /// map.truncate(2);
     /// assert_eq!(map.len(), 2);
+    /// assert_eq!(map.get(&1), None);
     ///
     /// let mut iter = map.iter();
     /// assert_eq!(iter.next(), Some((&3, &"a")));


### PR DESCRIPTION
Issue #559: `IndexMap::truncate` cleared the `entries`, but left dangling `indices`. This caused a `debug_assert` to fire if you searched for a key that had been truncated. Fixed by scanning the `indices` to remove the dangling ones, at the expense of making `truncate` O(n) instead of O(1). Added an assert to the doctest to catch this problem.


Fixes https://github.com/rust-embedded/heapless/issues/559.