### PR TITLE
CHANGELOG: mark 0.9.0 as yanked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Removed invalid `bytes::Buf` implementation.
 
-## [v0.9.0] - 2025-04-28
+## [v0.9.0] - 2025-04-28 [YANKED]
 
 ### Added
 


### PR DESCRIPTION
There is an unexpected regression in 0.9.0 with generics that is going to break a lot of code.
https://github.com/rust-embedded/heapless/issues/568