### PR TITLE
Prepare release 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.9.1] - 2025-08-19
+
 ### Added
 
 - Added `String::insert` and `String::insert_str`.
@@ -698,7 +700,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Initial release
 
-[Unreleased]: https://github.com/rust-embedded/heapless/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/rust-embedded/heapless/compare/v0.9.1...HEAD
+[v0.9.0]: https://github.com/rust-embedded/heapless/compare/v0.9.0...v0.9.1
 [v0.9.0]: https://github.com/rust-embedded/heapless/compare/v0.8.0...v0.9.0
 [v0.8.0]: https://github.com/rust-embedded/heapless/compare/v0.7.16...v0.8.0
 [v0.7.16]: https://github.com/rust-embedded/heapless/compare/v0.7.15...v0.7.16

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["static", "no-heap"]
 license = "MIT OR Apache-2.0"
 name = "heapless"
 repository = "https://github.com/rust-embedded/heapless"
-version = "0.9.0"
+version = "0.9.1"
 
 [features]
 bytes = ["dep:bytes"]


### PR DESCRIPTION
I think these should be merged first

- [x] #569 
- [x] #590
- [x] https://github.com/rust-embedded/heapless/pull/570