### PR TITLE
Better names for method returning mutable references

### DIFF
--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -193,7 +193,7 @@ impl<T, K, S: VecStorage<T>> BinaryHeapInner<T, K, S> {
     }
     /// Get a mutable reference to the `BinaryHeap`, erasing the `N` const-generic.
     pub fn as_mut_view(&mut self) -> &mut BinaryHeapView<T, K> {
-        S::as_binary_heap_mut_view(self)
+        S::as_binary_heap_view_mut(self)
     }
 }
 

--- a/src/deque.rs
+++ b/src/deque.rs
@@ -196,7 +196,7 @@ impl<T, S: VecStorage<T> + ?Sized> DequeInner<T, S> {
 
     /// Get a mutable reference to the `Deque`, erasing the `N` const-generic.
     pub fn as_mut_view(&mut self) -> &mut DequeView<T> {
-        S::as_deque_mut_view(self)
+        S::as_deque_view_mut(self)
     }
 
     /// Returns the maximum number of elements the deque can hold.

--- a/src/vec/mod.rs
+++ b/src/vec/mod.rs
@@ -61,7 +61,7 @@ mod storage {
         fn as_vec_view<LenT: LenType>(this: &VecInner<T, LenT, Self>) -> &VecView<T, LenT>
         where
             Self: VecStorage<T>;
-        fn as_vec_mut_view<LenT: LenType>(
+        fn as_vec_view_mut<LenT: LenType>(
             this: &mut VecInner<T, LenT, Self>,
         ) -> &mut VecView<T, LenT>
         where
@@ -70,7 +70,7 @@ mod storage {
         fn as_binary_heap_view<K>(this: &BinaryHeapInner<T, K, Self>) -> &BinaryHeapView<T, K>
         where
             Self: VecStorage<T>;
-        fn as_binary_heap_mut_view<K>(
+        fn as_binary_heap_view_mut<K>(
             this: &mut BinaryHeapInner<T, K, Self>,
         ) -> &mut BinaryHeapView<T, K>
         where
@@ -79,7 +79,7 @@ mod storage {
         fn as_deque_view(this: &DequeInner<T, Self>) -> &DequeView<T>
         where
             Self: VecStorage<T>;
-        fn as_deque_mut_view(this: &mut DequeInner<T, Self>) -> &mut DequeView<T>
+        fn as_deque_view_mut(this: &mut DequeInner<T, Self>) -> &mut DequeView<T>
         where
             Self: VecStorage<T>;
     }
@@ -108,7 +108,7 @@ mod storage {
         {
             this
         }
-        fn as_vec_mut_view<LenT: LenType>(
+        fn as_vec_view_mut<LenT: LenType>(
             this: &mut VecInner<T, LenT, Self>,
         ) -> &mut VecView<T, LenT>
         where
@@ -123,7 +123,7 @@ mod storage {
         {
             this
         }
-        fn as_binary_heap_mut_view<K>(
+        fn as_binary_heap_view_mut<K>(
             this: &mut BinaryHeapInner<T, K, Self>,
         ) -> &mut BinaryHeapView<T, K>
         where
@@ -137,7 +137,7 @@ mod storage {
         {
             this
         }
-        fn as_deque_mut_view(this: &mut DequeInner<T, Self>) -> &mut DequeView<T>
+        fn as_deque_view_mut(this: &mut DequeInner<T, Self>) -> &mut DequeView<T>
         where
             Self: VecStorage<T>,
         {
@@ -160,7 +160,7 @@ mod storage {
         {
             this
         }
-        fn as_vec_mut_view<LenT: LenType>(
+        fn as_vec_view_mut<LenT: LenType>(
             this: &mut VecInner<T, LenT, Self>,
         ) -> &mut VecView<T, LenT>
         where
@@ -175,7 +175,7 @@ mod storage {
         {
             this
         }
-        fn as_binary_heap_mut_view<K>(
+        fn as_binary_heap_view_mut<K>(
             this: &mut BinaryHeapInner<T, K, Self>,
         ) -> &mut BinaryHeapView<T, K>
         where
@@ -189,7 +189,7 @@ mod storage {
         {
             this
         }
-        fn as_deque_mut_view(this: &mut DequeInner<T, Self>) -> &mut DequeView<T>
+        fn as_deque_view_mut(this: &mut DequeInner<T, Self>) -> &mut DequeView<T>
         where
             Self: VecStorage<T>,
         {
@@ -528,7 +528,7 @@ impl<T, LenT: LenType, S: VecStorage<T> + ?Sized> VecInner<T, LenT, S> {
     /// ```
     #[inline]
     pub fn as_mut_view(&mut self) -> &mut VecView<T, LenT> {
-        S::as_vec_mut_view(self)
+        S::as_vec_view_mut(self)
     }
 
     /// Returns a raw pointer to the vector’s buffer.


### PR DESCRIPTION
I believe these names are better because they are more consistent with
the naming of their non-mutable siblings and also with the general
conventions in the Rust world.
