### PR TITLE
Remove duplicate documentation line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Minor fixes to module docs.
 - Make MSRV of 1.87.0 explicit.
 
 ## [v0.9.1] - 2025-08-19

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,23 +92,6 @@
             )
         )
     ),
-    doc = "- [`Arc`][pool::arc::Arc]: Like `std::sync::Arc` but backed by a lock-free memory pool rather than `[global_allocator]`."
-)]
-#![cfg_attr(
-    any(
-        arm_llsc,
-        all(
-            target_pointer_width = "32",
-            any(target_has_atomic = "64", feature = "portable-atomic")
-        ),
-        all(
-            target_pointer_width = "64",
-            any(
-                all(target_has_atomic = "128", feature = "nightly"),
-                feature = "portable-atomic"
-            )
-        )
-    ),
     doc = "- [`Object`](pool::object::Object): Objects managed by an object pool."
 )]
 //! - [`BinaryHeap`]: A priority queue.


### PR DESCRIPTION
Arc was added twice, evidently a copy-paste bug.

It does not appear that anything else is missing, so I just removed the duplicate line.