### PR TITLE
Add zeroization support for heapless data structures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
           components: miri
 
       - name: Run miri
-        run: MIRIFLAGS=-Zmiri-ignore-leaks cargo miri test --features="alloc,defmt,mpmc_large,portable-atomic-critical-section,serde,ufmt,bytes"
+        run: MIRIFLAGS=-Zmiri-ignore-leaks cargo miri test --features="alloc,defmt,mpmc_large,portable-atomic-critical-section,serde,ufmt,bytes,zeroize"
 
   # Run cargo test
   test:
@@ -84,7 +84,7 @@ jobs:
           toolchain: stable
 
       - name: Run cargo test
-        run: cargo test --features="alloc,defmt,mpmc_large,portable-atomic-critical-section,serde,ufmt,bytes"
+        run: cargo test --features="alloc,defmt,mpmc_large,portable-atomic-critical-section,serde,ufmt,bytes,zeroize"
 
   # Run cargo fmt --check
   style:
@@ -176,6 +176,7 @@ jobs:
           cargo check --target="${target}" --features="portable-atomic-critical-section"
           cargo check --target="${target}" --features="serde"
           cargo check --target="${target}" --features="ufmt"
+          cargo check --target="${target}" --features="zeroize"
         env:
           target: ${{ matrix.target }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Implement `defmt::Format` for `CapacityError`.
 - Implement `TryFrom` for `Deque` from array.
 - Switch from `serde` to `serde_core` for enabling faster compilations.
+- Implement `Zeroize` trait for all data structures with the `zeroize` feature to securely clear sensitive data from memory.
 
 ## [v0.9.1] - 2025-08-19
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,9 @@ ufmt = ["dep:ufmt", "dep:ufmt-write"]
 # Implement `defmt::Format`.
 defmt = ["dep:defmt"]
 
+# Implement `zeroize::Zeroize` trait.
+zeroize = ["dep:zeroize"]
+
 # Enable larger MPMC sizes.
 mpmc_large = []
 
@@ -63,6 +66,7 @@ serde_core = { version = "1", optional = true, default-features = false }
 ufmt = { version = "0.2", optional = true }
 ufmt-write = { version = "0.1", optional = true }
 defmt = { version = "1.0.1", optional = true }
+zeroize = { version = "1.8", optional = true, default-features = false, features = ["derive"] }
 
 # for the pool module
 [target.'cfg(any(target_arch = "arm", target_pointer_width = "32", target_pointer_width = "64"))'.dependencies]

--- a/src/len_type.rs
+++ b/src/len_type.rs
@@ -3,6 +3,9 @@ use core::{
     ops::{Add, AddAssign, Sub, SubAssign},
 };
 
+#[cfg(feature = "zeroize")]
+use zeroize::Zeroize;
+
 pub trait Sealed:
     Send
     + Sync
@@ -75,6 +78,15 @@ macro_rules! impl_lentype {
 /// A sealed trait representing a valid type to use as a length for a container.
 ///
 /// This cannot be implemented in user code, and is restricted to `u8`, `u16`, `u32`, and `usize`.
+///
+/// When the `zeroize` feature is enabled, this trait requires the `Zeroize` trait.
+#[cfg(feature = "zeroize")]
+pub trait LenType: Sealed + Zeroize {}
+
+/// A sealed trait representing a valid type to use as a length for a container.
+///
+/// This cannot be implemented in user code, and is restricted to `u8`, `u16`, `u32`, and `usize`.
+#[cfg(not(feature = "zeroize"))]
 pub trait LenType: Sealed {}
 
 impl_lentype!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,16 @@
 //! - [`mpmc::MpMcQueue`](mpmc): A lock-free multiple-producer, multiple-consumer queue.
 //! - [`spsc::Queue`](spsc): A lock-free single-producer, single-consumer queue.
 //!
+//! # Zeroize Support
+//!
+//! The `zeroize` feature enables secure memory wiping for the data structures via the [`zeroize`](https://crates.io/crates/zeroize)
+//! crate. Sensitive data can be properly erased from memory when no longer needed.
+//!
+//! When zeroizing a container, all underlying memory (including unused portion of the containers)
+//! is overwritten with zeros, length counters are reset, and the container is left in a valid but
+//! empty state that can be reused.
+//!
+//! Check the [documentation of the zeroize crate](https://docs.rs/zeroize/) for more information.
 //! # Minimum Supported Rust Version (MSRV)
 //!
 //! This crate does *not* have a Minimum Supported Rust Version (MSRV) and may make use of language


### PR DESCRIPTION
Implements zeroization support across all heapless data structures to securely clear sensitive data from memory:
  - Added Zeroize trait implementations for `Vector`, `CString`, `String`, `IndexMap`, `IndexSet`, and other structures
  - Created tests verifying proper zeroization behavior for each structure
  - Added necessary documentation

This feature is essential for security-sensitive applications needing to prevent data leaks from memory dumps.

Note: Zeroize initially worked on `Vector` purely via derivation, however was not complete without proper bound checks. Without these checks, the `deref` implementation of Zeroize was used instead, which led to incomplete zeroization of the Vector's contents.