### PR TITLE
Add `CowStr` enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ stable_deref_trait = { version = "1", default-features = false }
 [dev-dependencies]
 critical-section = { version = "1.1", features = ["std"] }
 static_assertions = "1.1.0"
+criterion = "0.5"
 
 [package.metadata.docs.rs]
 features = [
@@ -89,3 +90,8 @@ features = [
 # for the pool module
 targets = ["i686-unknown-linux-gnu"]
 rustdoc-args = ["--cfg", "docsrs"]
+
+[[bench]]
+name = "string_baseline"
+harness = false
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,11 @@ targets = ["i686-unknown-linux-gnu"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [[bench]]
+name = "cow_str"
+harness = false
+
+
+[[bench]]
 name = "string_baseline"
 harness = false
 

--- a/benches/cow_str.rs
+++ b/benches/cow_str.rs
@@ -1,0 +1,250 @@
+//! Criterion benchmarks for `CowStr` enum.
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use heapless::{cow::CowStr, String};
+
+fn create_test_string<const N: usize>(content: &str) -> String<N> {
+    String::try_from(content).expect("String too long for capacity")
+}
+
+fn cowstr_clone_on_mutation<'a, const N: usize>(
+    input: &'a String<N>,
+    needs_mutation: bool,
+) -> CowStr<'a, N> {
+    if needs_mutation {
+        let mut owned = input.clone();
+        let _ = owned.push_str("_mutated");
+        CowStr::Owned(owned)
+    } else {
+        CowStr::Borrowed(input.as_view())
+    }
+}
+
+fn bench_baseline_vs_cowstr(c: &mut Criterion) {
+    let mut group = c.benchmark_group("baseline_vs_cowstr");
+
+    let test_str: String<128> = create_test_string("test string for comparison");
+
+    group.bench_function("cowstr_no_mutation", |b| {
+        b.iter(|| {
+            let result = cowstr_clone_on_mutation(black_box(&test_str), false);
+            black_box(result)
+        });
+    });
+
+    group.bench_function("cowstr_with_mutation", |b| {
+        b.iter(|| {
+            let result = cowstr_clone_on_mutation(black_box(&test_str), true);
+            black_box(result)
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_cowstr_creation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cowstr_creation");
+
+    let short_str: String<16> = create_test_string("hello");
+    let medium_str: String<64> = create_test_string("This is a medium length test string");
+    let long_str: String<256> = create_test_string("This is a much longer test string that contains more characters to properly test the performance characteristics of the CowStr type with different sizes");
+
+    group.bench_function("borrowed_short", |b| {
+        b.iter(|| {
+            let view = black_box(&short_str).as_view();
+            black_box(CowStr::<16>::Borrowed(view))
+        });
+    });
+
+    group.bench_function("borrowed_medium", |b| {
+        b.iter(|| {
+            let view = black_box(&medium_str).as_view();
+            black_box(CowStr::<64>::Borrowed(view))
+        });
+    });
+
+    group.bench_function("borrowed_long", |b| {
+        b.iter(|| {
+            let view = black_box(&long_str).as_view();
+            black_box(CowStr::<256>::Borrowed(view))
+        });
+    });
+
+    group.bench_function("owned_short", |b| {
+        b.iter(|| {
+            let s = black_box(short_str.clone());
+            black_box(CowStr::<16>::Owned(s))
+        });
+    });
+
+    group.bench_function("owned_medium", |b| {
+        b.iter(|| {
+            let s = black_box(medium_str.clone());
+            black_box(CowStr::<64>::Owned(s))
+        });
+    });
+
+    group.bench_function("owned_long", |b| {
+        b.iter(|| {
+            let s = black_box(long_str.clone());
+            black_box(CowStr::<256>::Owned(s))
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_cowstr_as_str(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cowstr_as_str");
+
+    let test_str: String<64> = create_test_string("test string for as_str");
+    let borrowed = CowStr::<64>::Borrowed(test_str.as_view());
+    let owned = CowStr::<64>::Owned(test_str.clone());
+    let static_string: &'static String<64> = Box::leak(Box::new(test_str.clone()));
+    let static_cow = CowStr::<64>::Static(static_string.as_view());
+
+    group.bench_function("borrowed", |b| {
+        b.iter(|| black_box(&borrowed).as_str());
+    });
+
+    group.bench_function("static", |b| {
+        b.iter(|| black_box(&static_cow).as_str());
+    });
+
+    group.bench_function("owned", |b| {
+        b.iter(|| black_box(&owned).as_str());
+    });
+
+    group.finish();
+}
+
+fn bench_cowstr_to_owned_for_size<const N: usize>(
+    group: &mut criterion::BenchmarkGroup<criterion::measurement::WallTime>,
+    content: &str,
+    size: usize,
+) {
+    let test_str: String<N> = create_test_string(content);
+    let borrowed = CowStr::<N>::Borrowed(test_str.as_view());
+    let owned = CowStr::<N>::Owned(test_str.clone());
+
+    group.bench_with_input(BenchmarkId::new("borrowed", size), &size, |b, _| {
+        b.iter(|| black_box(&borrowed).to_owned());
+    });
+
+    group.bench_with_input(BenchmarkId::new("owned", size), &size, |b, _| {
+        b.iter(|| black_box(&owned).to_owned());
+    });
+}
+
+fn bench_cowstr_to_owned(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cowstr_to_owned");
+
+    bench_cowstr_to_owned_for_size::<16>(&mut group, "short", 16);
+    bench_cowstr_to_owned_for_size::<64>(
+        &mut group,
+        "This is a medium length string for testing",
+        64,
+    );
+    bench_cowstr_to_owned_for_size::<256>(
+        &mut group,
+        "This is a very long string that we use to test the performance of the to_owned method on CowStr with different string sizes and capacities to ensure proper benchmarking",
+        256,
+    );
+
+    group.finish();
+}
+
+fn bench_cowstr_type_checks(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cowstr_type_checks");
+
+    let test_str: String<64> = create_test_string("test");
+    let borrowed = CowStr::<64>::Borrowed(test_str.as_view());
+    let owned = CowStr::<64>::Owned(test_str.clone());
+    let static_string: &'static String<64> = Box::leak(Box::new(test_str.clone()));
+    let static_cow = CowStr::<64>::Static(static_string.as_view());
+
+    group.bench_function("is_borrowed", |b| {
+        b.iter(|| black_box(&borrowed).is_borrowed());
+    });
+
+    group.bench_function("is_static", |b| {
+        b.iter(|| black_box(&static_cow).is_static());
+    });
+
+    group.bench_function("is_owned", |b| {
+        b.iter(|| black_box(&owned).is_owned());
+    });
+
+    group.finish();
+}
+
+fn bench_cowstr_vs_clone(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cowstr_vs_clone");
+
+    let test_str: String<128> =
+        create_test_string("This is a string that would normally be cloned in every operation");
+
+    group.bench_function("cowstr_borrowed_read_only", |b| {
+        b.iter(|| {
+            let cow = CowStr::<128>::Borrowed(black_box(&test_str).as_view());
+            let _result = black_box(cow.as_str());
+        });
+    });
+
+    group.bench_function("string_clone_read_only", |b| {
+        b.iter(|| {
+            let s = black_box(&test_str).clone();
+            let _result = black_box(s.as_str());
+        });
+    });
+
+    group.bench_function("cowstr_to_owned_when_needed", |b| {
+        b.iter(|| {
+            let cow = CowStr::<128>::Borrowed(black_box(&test_str).as_view());
+            let _owned = black_box(cow.to_owned());
+        });
+    });
+
+    group.bench_function("string_clone_when_needed", |b| {
+        b.iter(|| {
+            let s = black_box(&test_str).clone();
+            let _owned = black_box(s);
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_cowstr_from(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cowstr_from");
+
+    let test_str: String<64> = create_test_string("test string");
+
+    group.bench_function("from_stringview", |b| {
+        b.iter(|| {
+            let view = black_box(&test_str).as_view();
+            black_box(CowStr::<64>::from(view))
+        });
+    });
+
+    group.bench_function("from_string", |b| {
+        b.iter(|| {
+            let s = black_box(&test_str).clone();
+            black_box(CowStr::<64>::from(s))
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_baseline_vs_cowstr,
+    bench_cowstr_creation,
+    bench_cowstr_as_str,
+    bench_cowstr_to_owned,
+    bench_cowstr_type_checks,
+    bench_cowstr_vs_clone,
+    bench_cowstr_from
+);
+criterion_main!(benches);

--- a/benches/string_baseline.rs
+++ b/benches/string_baseline.rs
@@ -1,0 +1,156 @@
+//! Baseline benchmarks for heapless String operations.
+//!
+//! This benchmark suite measures the performance characteristics of basic
+//! String operations to establish a baseline for comparison.
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use heapless::String;
+
+fn create_test_string<const N: usize>(content: &str) -> String<N> {
+    String::try_from(content).expect("String too long for capacity")
+}
+
+/// Baseline function that always copies into a new String<N>.
+fn baseline_always_copy<const N: usize>(input: &String<N>) -> String<N> {
+    input.clone()
+}
+
+/// Function that sometimes mutates the string (requires clone).
+fn baseline_conditional_mutation<const N: usize>(
+    input: &String<N>,
+    needs_mutation: bool,
+) -> String<N> {
+    if needs_mutation {
+        let mut owned = input.clone();
+        let _ = owned.push_str("_mutated");
+        owned
+    } else {
+        input.clone()
+    }
+}
+
+fn bench_string_baseline(c: &mut Criterion) {
+    let mut group = c.benchmark_group("string_baseline");
+
+    let test_str: String<128> = create_test_string("test string for comparison");
+
+    group.bench_function("always_copy", |b| {
+        b.iter(|| {
+            let result = baseline_always_copy(black_box(&test_str));
+            black_box(result)
+        });
+    });
+
+    group.bench_function("no_mutation", |b| {
+        b.iter(|| {
+            let result = baseline_conditional_mutation(black_box(&test_str), false);
+            black_box(result)
+        });
+    });
+
+    group.bench_function("with_mutation", |b| {
+        b.iter(|| {
+            let result = baseline_conditional_mutation(black_box(&test_str), true);
+            black_box(result)
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_string_creation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("string_creation");
+
+    let short_str: String<16> = create_test_string("hello");
+    let medium_str: String<64> = create_test_string("This is a medium length test string");
+    let long_str: String<256> = create_test_string("This is a much longer test string that contains more characters to properly test the performance characteristics");
+
+    group.bench_function("clone_short", |b| {
+        b.iter(|| black_box(short_str.clone()));
+    });
+
+    group.bench_function("clone_medium", |b| {
+        b.iter(|| black_box(medium_str.clone()));
+    });
+
+    group.bench_function("clone_long", |b| {
+        b.iter(|| black_box(long_str.clone()));
+    });
+
+    group.finish();
+}
+
+fn bench_string_as_str(c: &mut Criterion) {
+    let mut group = c.benchmark_group("string_as_str");
+
+    let test_str: String<64> = create_test_string("test string for as_str");
+
+    group.bench_function("as_str", |b| {
+        b.iter(|| black_box(&test_str).as_str());
+    });
+
+    group.finish();
+}
+
+fn bench_string_clone_for_size<const N: usize>(
+    group: &mut criterion::BenchmarkGroup<criterion::measurement::WallTime>,
+    content: &str,
+    size: usize,
+) {
+    let test_str: String<N> = create_test_string(content);
+
+    group.bench_with_input(BenchmarkId::new("clone", size), &size, |b, _| {
+        b.iter(|| black_box(&test_str).clone());
+    });
+}
+
+fn bench_string_clone_sizes(c: &mut Criterion) {
+    let mut group = c.benchmark_group("string_clone_sizes");
+
+    bench_string_clone_for_size::<16>(&mut group, "short", 16);
+    bench_string_clone_for_size::<64>(
+        &mut group,
+        "This is a medium length string for testing",
+        64,
+    );
+    bench_string_clone_for_size::<256>(
+        &mut group,
+        "This is a very long string that we use to test the performance with different string sizes and capacities to ensure proper benchmarking",
+        256,
+    );
+
+    group.finish();
+}
+
+fn bench_string_vs_clone(c: &mut Criterion) {
+    let mut group = c.benchmark_group("string_vs_clone");
+
+    let test_str: String<128> =
+        create_test_string("This is a string that would normally be cloned in every operation");
+
+    group.bench_function("clone_read_only", |b| {
+        b.iter(|| {
+            let s = black_box(&test_str).clone();
+            let _result = black_box(s.as_str());
+        });
+    });
+
+    group.bench_function("clone_when_needed", |b| {
+        b.iter(|| {
+            let s = black_box(&test_str).clone();
+            let _owned = black_box(s);
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_string_baseline,
+    bench_string_creation,
+    bench_string_as_str,
+    bench_string_clone_sizes,
+    bench_string_vs_clone
+);
+criterion_main!(benches);

--- a/benches/string_baseline.rs
+++ b/benches/string_baseline.rs
@@ -4,28 +4,28 @@
 //! String operations to establish a baseline for comparison.
 
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use heapless::String;
+use heapless::{cow::CowStr, String};
 
 fn create_test_string<const N: usize>(content: &str) -> String<N> {
     String::try_from(content).expect("String too long for capacity")
 }
 
 /// Baseline function that always copies into a new String<N>.
-fn baseline_always_copy<const N: usize>(input: &String<N>) -> String<N> {
-    input.clone()
+fn baseline_always_copy<const N: usize>(input: &String<N>) -> CowStr<'_, N> {
+    CowStr::Owned(input.clone())
 }
 
 /// Function that sometimes mutates the string (requires clone).
 fn baseline_conditional_mutation<const N: usize>(
     input: &String<N>,
     needs_mutation: bool,
-) -> String<N> {
+) -> CowStr<'_, N> {
     if needs_mutation {
         let mut owned = input.clone();
         let _ = owned.push_str("_mutated");
-        owned
+        CowStr::Owned(owned)
     } else {
-        input.clone()
+        CowStr::Borrowed(input.as_view())
     }
 }
 

--- a/src/cow.rs
+++ b/src/cow.rs
@@ -1,0 +1,106 @@
+//! Clone-on-write string type for heapless.
+//! 
+//! Provides `CowStr`, a heapless clone-on-write string that can be borrowed or owned.
+
+use crate::len_type::LenType;
+use crate::string::StringView;
+use crate::String;
+use core::borrow::Borrow;
+
+/// A clone-on-write (COW) string type specialized for heapless strings.
+///
+/// `CowStr` can be either:
+/// - `Borrowed(&'a StringView<LenT>)` for a non-`'static` borrowed view,
+/// - `Static(&'static StringView<LenT>)` for a `'static` borrowed view,
+/// - `Owned(String<N, LenT>)` for an owned heapless `String`.
+#[derive(Debug, Clone)]
+pub enum CowStr<'a, const N: usize, LenT: LenType = usize>
+where
+    LenT: 'static,
+{
+    /// A borrowed view with lifetime `'a`.
+    Borrowed(&'a StringView<LenT>),
+    /// A `'static` borrowed view.
+    Static(&'static StringView<LenT>),
+    /// An owned `String` with inline storage of size `N`.
+    Owned(String<N, LenT>),
+}
+
+impl<'a, const N: usize, LenT: LenType> CowStr<'a, N, LenT>
+where
+    LenT: 'static,
+{
+    /// Convert the `CowStr` into an owned `String<N, LenT>`.
+    ///
+    /// Panics if the string does not fit in `N`.
+    pub fn to_owned(&self) -> String<N, LenT> {
+        match self {
+            CowStr::Borrowed(sv) => String::try_from(sv.as_str())
+                .expect("capacity too small for CowStr::to_owned"),
+            CowStr::Static(sv) => String::try_from(sv.as_str())
+                .expect("capacity too small for CowStr::to_owned"),
+            CowStr::Owned(s) => s.clone(),
+        }
+    }
+
+    /// Return the inner value as `&str`.
+    pub fn as_str(&self) -> &str {
+        match self {
+            CowStr::Borrowed(sv) => sv.as_str(),
+            CowStr::Static(sv) => sv.as_str(),
+            CowStr::Owned(s) => s.as_str(),
+        }
+    }
+
+    /// Is this a non-`'static` borrowed view?
+    pub fn is_borrowed(&self) -> bool {
+        matches!(self, CowStr::Borrowed(_))
+    }
+
+    /// Is this a `'static` borrowed view?
+    pub fn is_static(&self) -> bool {
+        matches!(self, CowStr::Static(_))
+    }
+
+    /// Is this an owned string?
+    pub fn is_owned(&self) -> bool {
+        matches!(self, CowStr::Owned(_))
+    }
+}
+
+impl<'a, const N: usize, LenT: LenType> From<&'a StringView<LenT>> for CowStr<'a, N, LenT>
+where
+    LenT: 'static,
+{
+    fn from(sv: &'a StringView<LenT>) -> Self {
+        CowStr::Borrowed(sv)
+    }
+}
+
+impl<const N: usize, LenT: LenType> From<String<N, LenT>> for CowStr<'_, N, LenT>
+where
+    LenT: 'static,
+{
+    fn from(s: String<N, LenT>) -> Self {
+        CowStr::Owned(s)
+    }
+}
+
+impl<const N: usize, LenT: LenType> CowStr<'static, N, LenT>
+where
+    LenT: 'static,
+{
+    /// Construct a `CowStr` that holds a `'static` `StringView`.
+    pub const fn from_static(sv: &'static StringView<LenT>) -> Self {
+        CowStr::Static(sv)
+    }
+}
+
+impl<'a, const N: usize, LenT: LenType> Borrow<str> for CowStr<'a, N, LenT>
+where
+    LenT: 'static,
+{
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,7 @@ pub mod linear_map;
 mod slice;
 pub mod storage;
 pub mod string;
+pub mod cow;
 pub mod vec;
 
 // FIXME: Workaround a compiler ICE in rust 1.83 to 1.86


### PR DESCRIPTION
### Overview
This PR adds a `Cow<'a, N, LenT>` type to the heapless crate, enabling efficient clone-on-write strings compatible with heapless data structures.

### Features
- `Cow::Borrowed(&StringView<LenT>)` for zero-copy references.
- `Cow::Owned(String<N, LenT>)` for owned heapless strings.
- Conversion helpers: `to_owned()`, `as_str()`, `is_borrowed()`, `is_owned()`.
- `From<&StringView<LenT>>` and `From<String<N, LenT>>` for easy construction.
- Implements `Borrow<str>` for compatibility with APIs expecting `&str`.

### Motivation
Currently, heapless strings require manual cloning or reference handling. `Cow` simplifies this by providing a single type that can efficiently represent either a borrowed or owned string.

### Testing
Verified compilation and basic API usage. Unit tests for `Cow` will follow in a separate PR.

- This PR addresses issue #582 