### PR TITLE
Add FromIterator implementation for Deque

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Bump MSRV to 1.88 (requires by trybuild dev dependency).
 - Fixed unsoundness in `Vec::IntoIter::drop` and `HistoryBuf::write`in the context of panicking drop implementations.
 - Added `push_mut` to `Vec`.
+- Implemented `FromIterator` for `Deque`.
 - Fixed unsoundness in `IndexMap:insert`.
 - Limited max size of `IndexMap` to u16::MAX + 1.
   The implementation for sizes higher than u16::MAX were unsound anyway.

--- a/src/deque.rs
+++ b/src/deque.rs
@@ -1246,6 +1246,18 @@ impl<'a, T: 'a + Copy, S: VecStorage<T> + ?Sized> Extend<&'a T> for DequeInner<T
     }
 }
 
+impl<T, const N: usize> FromIterator<T> for Deque<T, N> {
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let mut deque = Self::new();
+        deque.extend(iter);
+
+        deque
+    }
+}
+
 /// An iterator that moves out of a [`Deque`].
 ///
 /// This struct is created by calling the `into_iter` method.
@@ -1551,6 +1563,30 @@ mod tests {
         let mut v: Deque<i32, 4> = Deque::new();
         // Is too many elements -> should panic
         v.extend(&[1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn from_iter() {
+        // Iterator is empty.
+        let deq: Deque<i32, 4> = core::iter::empty().collect();
+        assert!(deq.is_empty());
+
+        // Iterator is under limit.
+        let deq: Deque<i32, 4> = [1, 2, 3].into_iter().collect();
+        assert!(!deq.is_full());
+        assert_eq!(deq.as_slices(), (&[1, 2, 3][..], &[][..]));
+
+        // Iterator is at limit.
+        let deq: Deque<i32, 4> = [1, 2, 3, 4].into_iter().collect();
+        assert!(deq.is_full());
+        assert_eq!(deq.as_slices(), (&[1, 2, 3, 4][..], &[][..]));
+    }
+
+    #[test]
+    #[should_panic]
+    fn from_iter_panic() {
+        // Too many elements (4 vs 5)
+        let _: Deque<i32, 4> = [1, 2, 3, 4, 5].into_iter().collect();
     }
 
     #[test]


### PR DESCRIPTION
Fixes https://github.com/rust-embedded/heapless/issues/683

I took the simplest possible route of just reusing the `Extend` implementation